### PR TITLE
Flink: Normalize delete-orphan location and block traversal escapes

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
@@ -158,7 +158,8 @@ public class DeleteOrphanFilesConfig {
 
     String normalizedLocation = LocationUtil.stripTrailingSlash(newLocation);
     Preconditions.checkArgument(
-        normalizedLocation.equals(tableLocation) || normalizedLocation.startsWith(tableLocation + "/"),
+        normalizedLocation.equals(tableLocation)
+            || normalizedLocation.startsWith(tableLocation + "/"),
         "Invalid %s: %s. The location must be within the table location: %s",
         LOCATION,
         newLocation,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.maintenance.api;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import org.apache.flink.configuration.ConfigOption;
@@ -119,7 +120,7 @@ public class DeleteOrphanFilesConfig {
   public DeleteOrphanFilesConfig(
       Table table, Map<String, String> writeOptions, ReadableConfig readableConfig) {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
-    this.tableLocation = LocationUtil.stripTrailingSlash(table.location());
+    this.tableLocation = normalizeLocation(table.location());
   }
 
   public long scheduleOnIntervalSecond() {
@@ -156,7 +157,9 @@ public class DeleteOrphanFilesConfig {
       return null;
     }
 
-    String normalizedLocation = LocationUtil.stripTrailingSlash(newLocation);
+    Preconditions.checkArgument(!newLocation.isEmpty(), "Invalid %s: must not be empty", LOCATION);
+
+    String normalizedLocation = normalizeLocation(newLocation);
     Preconditions.checkArgument(
         normalizedLocation.equals(tableLocation)
             || normalizedLocation.startsWith(tableLocation + "/"),
@@ -164,7 +167,7 @@ public class DeleteOrphanFilesConfig {
         LOCATION,
         newLocation,
         tableLocation);
-    return newLocation;
+    return normalizedLocation;
   }
 
   public boolean usePrefixListing() {
@@ -229,5 +232,15 @@ public class DeleteOrphanFilesConfig {
     }
 
     return result;
+  }
+
+  private static String normalizeLocation(String location) {
+    String stripped = LocationUtil.stripTrailingSlash(location);
+    try {
+      URI normalized = URI.create(stripped).normalize();
+      return LocationUtil.stripTrailingSlash(normalized.toString());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(String.format("Invalid %s: %s", LOCATION, location), e);
+    }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/DeleteOrphanFilesConfig.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.flink.FlinkConfParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.ThreadPools;
 
 public class DeleteOrphanFilesConfig {
@@ -113,10 +114,12 @@ public class DeleteOrphanFilesConfig {
                   + "Valid values: ERROR, IGNORE, DELETE.");
 
   private final FlinkConfParser confParser;
+  private final String tableLocation;
 
   public DeleteOrphanFilesConfig(
       Table table, Map<String, String> writeOptions, ReadableConfig readableConfig) {
     this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
+    this.tableLocation = LocationUtil.stripTrailingSlash(table.location());
   }
 
   public long scheduleOnIntervalSecond() {
@@ -147,7 +150,20 @@ public class DeleteOrphanFilesConfig {
   }
 
   public String location() {
-    return confParser.stringConf().option(LOCATION).flinkConfig(LOCATION_OPTION).parseOptional();
+    String newLocation =
+        confParser.stringConf().option(LOCATION).flinkConfig(LOCATION_OPTION).parseOptional();
+    if (newLocation == null) {
+      return null;
+    }
+
+    String normalizedLocation = LocationUtil.stripTrailingSlash(newLocation);
+    Preconditions.checkArgument(
+        normalizedLocation.equals(tableLocation) || normalizedLocation.startsWith(tableLocation + "/"),
+        "Invalid %s: %s. The location must be within the table location: %s",
+        LOCATION,
+        newLocation,
+        tableLocation);
+    return newLocation;
   }
 
   public boolean usePrefixListing() {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFilesConfig.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFilesConfig.java
@@ -92,12 +92,42 @@ public class TestDeleteOrphanFilesConfig extends OperatorTestBase {
 
   @Test
   void testLocationValidation() {
-    input.put(DeleteOrphanFilesConfig.LOCATION, table.location() + "-outside");
+    String[] invalidLocations =
+        new String[] {
+          table.location() + "-outside",
+          table.location() + "/../outside",
+          table.location() + "/sub/../../outside"
+        };
+
+    for (String invalidLocation : invalidLocations) {
+      input.put(DeleteOrphanFilesConfig.LOCATION, invalidLocation);
+
+      DeleteOrphanFilesConfig config =
+          new DeleteOrphanFilesConfig(table, input, new Configuration());
+
+      assertThatThrownBy(config::location)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("The location must be within the table location");
+    }
+  }
+
+  @Test
+  void testEmptyLocationIsRejected() {
+    input.put(DeleteOrphanFilesConfig.LOCATION, "");
 
     DeleteOrphanFilesConfig config = new DeleteOrphanFilesConfig(table, input, new Configuration());
 
     assertThatThrownBy(config::location)
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("The location must be within the table location");
+        .hasMessageContaining("must not be empty");
+  }
+
+  @Test
+  void testLocationNormalization() {
+    input.put(DeleteOrphanFilesConfig.LOCATION, table.location() + "/subdir/../inside");
+
+    DeleteOrphanFilesConfig config = new DeleteOrphanFilesConfig(table, input, new Configuration());
+
+    assertThat(config.location()).isEqualTo(table.location() + "/inside");
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFilesConfig.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestDeleteOrphanFilesConfig.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 import org.apache.flink.configuration.Configuration;
@@ -41,7 +42,7 @@ public class TestDeleteOrphanFilesConfig extends OperatorTestBase {
     input.put(DeleteOrphanFilesConfig.SCHEDULE_ON_INTERVAL_SECOND, "60");
     input.put(DeleteOrphanFilesConfig.MIN_AGE_SECONDS, "86400");
     input.put(DeleteOrphanFilesConfig.DELETE_BATCH_SIZE, "500");
-    input.put(DeleteOrphanFilesConfig.LOCATION, "/tmp/test-location");
+    input.put(DeleteOrphanFilesConfig.LOCATION, table.location() + "/test-location");
     input.put(DeleteOrphanFilesConfig.USE_PREFIX_LISTING, "true");
     input.put(DeleteOrphanFilesConfig.PLANNING_WORKER_POOL_SIZE, "4");
     input.put(DeleteOrphanFilesConfig.EQUAL_SCHEMES, "s3n=s3,s3a=s3");
@@ -62,7 +63,7 @@ public class TestDeleteOrphanFilesConfig extends OperatorTestBase {
     assertThat(config.scheduleOnIntervalSecond()).isEqualTo(60);
     assertThat(config.minAgeSeconds()).isEqualTo(86400L);
     assertThat(config.deleteBatchSize()).isEqualTo(500);
-    assertThat(config.location()).isEqualTo("/tmp/test-location");
+    assertThat(config.location()).isEqualTo(table.location() + "/test-location");
     assertThat(config.usePrefixListing()).isTrue();
     assertThat(config.planningWorkerPoolSize()).isEqualTo(4);
     assertThat(config.equalSchemes()).containsEntry("s3n", "s3").containsEntry("s3a", "s3");
@@ -87,5 +88,16 @@ public class TestDeleteOrphanFilesConfig extends OperatorTestBase {
     assertThat(config.equalSchemes()).containsEntry("s3n", "s3").containsEntry("s3a", "s3");
     assertThat(config.equalAuthorities()).isEqualTo(Map.of());
     assertThat(config.prefixMismatchMode()).isEqualTo(PrefixMismatchMode.ERROR);
+  }
+
+  @Test
+  void testLocationValidation() {
+    input.put(DeleteOrphanFilesConfig.LOCATION, table.location() + "-outside");
+
+    DeleteOrphanFilesConfig config = new DeleteOrphanFilesConfig(table, input, new Configuration());
+
+    assertThatThrownBy(config::location)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("The location must be within the table location");
   }
 }


### PR DESCRIPTION
Flink orphan-file maintenance needed to prevent user-supplied locations from escaping the table root and to reject empty values.

- Validation
  - Normalize both table and configured locations (URI normalize + trailing slash strip) and return the normalized path.
  - Reject empty `flink-maintenance.delete-orphan-files.location` with an option-specific error.
  - Guard comparisons so traversal segments (`..`, `.`) cannot bypass the table root.
- Tests
  - Add traversal/normalization rejection cases and empty-location coverage.
  - Assert normalized in-table paths are accepted.

Example:
```java
String normalizedLocation = normalizeLocation(newLocation);
Preconditions.checkArgument(
    normalizedLocation.equals(tableLocation) || normalizedLocation.startsWith(tableLocation + "/"),
    "Invalid %s: %s. The location must be within the table location: %s",
    LOCATION, newLocation, tableLocation);
```