### PR TITLE
Core: Enforce token-exchange refresh and align catalog tests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthConfig.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthConfig.java
@@ -89,11 +89,6 @@ public interface AuthConfig {
                 properties,
                 OAuth2Properties.TOKEN_REFRESH_ENABLED,
                 OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT))
-        .exchangeEnabled(
-            PropertyUtil.propertyAsBoolean(
-                properties,
-                OAuth2Properties.TOKEN_EXCHANGE_ENABLED,
-                OAuth2Properties.TOKEN_EXCHANGE_ENABLED_DEFAULT))
         .expiresAtMillis(expiresAtMillis(properties))
         .build();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -161,37 +161,23 @@ public class OAuth2Util {
       String subjectToken,
       String subjectTokenType,
       Map<String, String> optionalOAuthParams) {
-    if (config.exchangeEnabled()) {
-      Map<String, String> request =
-          tokenExchangeRequest(
-              subjectToken,
-              subjectTokenType,
-              config.scope() != null ? ImmutableList.of(config.scope()) : ImmutableList.of(),
-              optionalOAuthParams);
+    Map<String, String> request =
+        tokenExchangeRequest(
+            subjectToken,
+            subjectTokenType,
+            config.scope() != null ? ImmutableList.of(config.scope()) : ImmutableList.of(),
+            optionalOAuthParams);
 
-      OAuthTokenResponse response =
-          client.postForm(
-              config.oauth2ServerUri(),
-              request,
-              OAuthTokenResponse.class,
-              headers,
-              ErrorHandlers.oauthErrorHandler());
-      response.validate();
+    OAuthTokenResponse response =
+        client.postForm(
+            config.oauth2ServerUri(),
+            request,
+            OAuthTokenResponse.class,
+            headers,
+            ErrorHandlers.oauthErrorHandler());
+    response.validate();
 
-      return response;
-    } else {
-      if (null == config.credential()) {
-        return null;
-      }
-
-      return fetchToken(
-          client,
-          Map.of(),
-          config.credential(),
-          config.scope(),
-          config.oauth2ServerUri(),
-          ImmutableMap.of());
-    }
+    return response;
   }
 
   public static OAuthTokenResponse exchangeToken(
@@ -547,7 +533,8 @@ public class OAuth2Util {
         return refreshExpiredToken(client);
       } else {
         // attempt a normal refresh
-        return refreshToken(client, config, headers(), token(), tokenType(), optionalOAuthParams());
+        return refreshToken(
+            client, config, headers(), token(), tokenType(), optionalOAuthParams());
       }
     }
 
@@ -556,15 +543,10 @@ public class OAuth2Util {
         return null;
       }
 
-      if (config.exchangeEnabled()) {
-        Map<String, String> basicHeaders =
-            RESTUtil.merge(headers(), basicAuthHeaders(credential()));
-        return refreshToken(
-            client, config, basicHeaders, token(), tokenType(), optionalOAuthParams());
-      } else {
-        return fetchToken(
-            client, Map.of(), credential(), scope(), oauth2ServerUri(), ImmutableMap.of());
-      }
+      Map<String, String> basicHeaders =
+          RESTUtil.merge(headers(), basicAuthHeaders(credential()));
+      return refreshToken(
+          client, config, basicHeaders, token(), tokenType(), optionalOAuthParams());
     }
 
     /**

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -533,8 +533,7 @@ public class OAuth2Util {
         return refreshExpiredToken(client);
       } else {
         // attempt a normal refresh
-        return refreshToken(
-            client, config, headers(), token(), tokenType(), optionalOAuthParams());
+        return refreshToken(client, config, headers(), token(), tokenType(), optionalOAuthParams());
       }
     }
 
@@ -543,8 +542,7 @@ public class OAuth2Util {
         return null;
       }
 
-      Map<String, String> basicHeaders =
-          RESTUtil.merge(headers(), basicAuthHeaders(credential()));
+      Map<String, String> basicHeaders = RESTUtil.merge(headers(), basicAuthHeaders(credential()));
       return refreshToken(
           client, config, basicHeaders, token(), tokenType(), optionalOAuthParams());
     }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1614,9 +1614,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     Map<String, String> refreshRequest =
         ImmutableMap.of(
-            "grant_type", "client_credentials",
-            "client_id", "catalog",
-            "client_secret", "secret",
+            "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token", "client-credentials-token:sub=catalog",
+            "subject_token_type", "urn:ietf:params:oauth:token-type:access_token",
             "scope", "catalog");
 
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
@@ -1679,7 +1679,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Mockito.verify(adapter)
                   .execute(
                       matches(
-                          HTTPMethod.POST, oauth2ServerUri, emptyHeaders, Map.of(), refreshRequest),
+                          HTTPMethod.POST,
+                          oauth2ServerUri,
+                          catalogHeaders,
+                          Map.of(),
+                          refreshRequest),
                       eq(OAuthTokenResponse.class),
                       any(),
                       any());
@@ -1743,6 +1747,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             "client_id", "catalog",
             "client_secret", "12345",
             "scope", "catalog");
+
     Mockito.verify(adapter)
         .execute(
             matches(
@@ -1859,10 +1864,17 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             any(),
             any());
 
+    Map<String, String> basicHeaders = OAuth2Util.basicAuthHeaders(credential);
+    Map<String, String> refreshRequest =
+        ImmutableMap.of(
+            "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token", token,
+            "subject_token_type", "urn:ietf:params:oauth:token-type:access_token",
+            "scope", "catalog");
+
     Mockito.verify(adapter)
         .execute(
-            matches(
-                HTTPMethod.POST, oauth2ServerUri, emptyHeaders, Map.of(), clientCredentialsRequest),
+            matches(HTTPMethod.POST, oauth2ServerUri, basicHeaders, Map.of(), refreshRequest),
             eq(OAuthTokenResponse.class),
             any(),
             any());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -1607,10 +1607,11 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @ParameterizedTest
   @ValueSource(strings = {"v1/oauth/tokens", "https://auth-server.com/token"})
-  public void testCatalogTokenRefreshExchangeDisabled(String oauth2ServerUri) {
+  public void testCatalogTokenRefreshIgnoresClientExchangeDisabled(String oauth2ServerUri) {
     Map<String, String> emptyHeaders = ImmutableMap.of();
     Map<String, String> catalogHeaders =
         ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=catalog");
+    Map<String, String> refreshHeaders = OAuth2Util.basicAuthHeaders("catalog:secret");
 
     Map<String, String> refreshRequest =
         ImmutableMap.of(
@@ -1681,7 +1682,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                       matches(
                           HTTPMethod.POST,
                           oauth2ServerUri,
-                          catalogHeaders,
+                          refreshHeaders,
                           Map.of(),
                           refreshRequest),
                       eq(OAuthTokenResponse.class),

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.rest.auth;
 
 import static org.apache.hadoop.hdfs.web.oauth2.OAuth2Constants.BEARER;
-import static org.apache.hadoop.hdfs.web.oauth2.OAuth2Constants.CLIENT_CREDENTIALS;
 import static org.apache.hadoop.hdfs.web.oauth2.OAuth2Constants.GRANT_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -103,7 +102,7 @@ public class TestOAuth2Util {
   }
 
   @Test
-  public void testCredentialFlowForSessionRefresh() throws IOException {
+  public void testTokenExchangeFlowForSessionRefresh() throws IOException {
     AuthConfig authConfig =
         ImmutableAuthConfig.builder()
             .keepRefreshed(true)
@@ -129,7 +128,9 @@ public class TestOAuth2Util {
               argThat(
                   formData ->
                       formData.containsKey(GRANT_TYPE)
-                          && formData.get(GRANT_TYPE).equals(CLIENT_CREDENTIALS)),
+                          && formData
+                              .get(GRANT_TYPE)
+                              .equals("urn:ietf:params:oauth:grant-type:token-exchange")),
               Mockito.eq(OAuthTokenResponse.class),
               anyMap(),
               any());

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -27,12 +27,16 @@ import static org.mockito.ArgumentMatchers.argThat;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestOAuth2Util {
+  private static final String TOKEN_EXCHANGE_GRANT =
+      "urn:ietf:params:oauth:grant-type:token-exchange";
+
   @Test
   public void testOAuthScopeTokenValidation() {
     // valid scope tokens are from ascii 0x21 to 0x7E, excluding 0x22 (") and 0x5C (\)
@@ -128,9 +132,7 @@ public class TestOAuth2Util {
               argThat(
                   formData ->
                       formData.containsKey(GRANT_TYPE)
-                          && formData
-                              .get(GRANT_TYPE)
-                              .equals("urn:ietf:params:oauth:grant-type:token-exchange")),
+                          && Objects.equals(TOKEN_EXCHANGE_GRANT, formData.get(GRANT_TYPE))),
               Mockito.eq(OAuthTokenResponse.class),
               anyMap(),
               any());


### PR DESCRIPTION
Token refresh could mint tokens via client credentials when client-supplied properties disabled exchange, bypassing per-user auth.

- **Auth config**: Stop reading `token-exchange-enabled` from runtime props; only server config governs exchange.
- **Refresh path**: Always exchange the subject token in `OAuth2Util` (no client-credentials fallback).
- **Tests**: Assert token-exchange grant with a shared constant/null-safe matcher; rename catalog refresh test to reflect ignored client disable flag; verify refresh calls send Basic auth to the token endpoint.

Example:
```java
// refresh now always exchanges the subject token
return refreshToken(client, config, headers(), token(), tokenType(), optionalOAuthParams());
```