### PR TITLE
Core: Rebuild cached 304 tables with current session context

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -542,9 +542,6 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     List<Credential> credentials = response.credentials();
-    if (credentials == null) {
-      credentials = ImmutableList.of();
-    }
     RESTClient tableClient = client.withAuthSession(tableSession);
     Supplier<BaseTable> tableSupplier =
         createTableSupplier(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -474,7 +474,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       if (response == null) {
         Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
 
-        return cachedTable.supplier().get();
+        return tableWithCurrentContext(context, identifier, cachedTable);
       }
 
       loadedIdent = identifier;
@@ -493,15 +493,16 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               loadInternal(
                   context,
                   baseIdent,
-                  snapshotMode,
-                  headersForLoadTable(cachedTable),
-                  responseHeaders::putAll);
+              snapshotMode,
+              headersForLoadTable(cachedTable),
+              responseHeaders::putAll);
 
           if (response == null) {
             Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");
 
-            return MetadataTableUtils.createMetadataTableInstance(
-                cachedTable.supplier().get(), metadataType);
+            BaseTable table = tableWithCurrentContext(context, baseIdent, cachedTable);
+
+            return MetadataTableUtils.createMetadataTableInstance(table, metadataType);
           }
 
           loadedIdent = baseIdent;
@@ -541,6 +542,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
 
     List<Credential> credentials = response.credentials();
+    if (credentials == null) {
+      credentials = ImmutableList.of();
+    }
     RESTClient tableClient = client.withAuthSession(tableSession);
     Supplier<BaseTable> tableSupplier =
         createTableSupplier(
@@ -548,12 +552,38 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     String eTag = responseHeaders.getOrDefault(HttpHeaders.ETAG, null);
     if (eTag != null) {
-      tableCache.put(context.sessionId(), finalIdentifier, tableSupplier, eTag);
+      tableCache.put(
+          context.sessionId(),
+          finalIdentifier,
+          tableSupplier,
+          eTag,
+          tableMetadata,
+          tableConf,
+          credentials);
     }
 
     if (metadataType != null) {
       return MetadataTableUtils.createMetadataTableInstance(tableSupplier.get(), metadataType);
     }
+
+    return tableSupplier.get();
+  }
+
+  private BaseTable tableWithCurrentContext(
+      SessionContext context, TableIdentifier identifier, TableWithETag cachedTable) {
+    AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+    AuthSession tableSession =
+        authManager.tableSession(identifier, cachedTable.tableConfig(), contextualSession);
+    RESTClient tableClient = client.withAuthSession(tableSession);
+
+    Supplier<BaseTable> tableSupplier =
+        createTableSupplier(
+            identifier,
+            cachedTable.tableMetadata(),
+            context,
+            tableClient,
+            cachedTable.tableConfig(),
+            cachedTable.credentials());
 
     return tableSupplier.get();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -493,9 +493,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               loadInternal(
                   context,
                   baseIdent,
-              snapshotMode,
-              headersForLoadTable(cachedTable),
-              responseHeaders::putAll);
+                  snapshotMode,
+                  headersForLoadTable(cachedTable),
+                  responseHeaders::putAll);
 
           if (response == null) {
             Preconditions.checkNotNull(cachedTable, "Invalid load table response: null");

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
@@ -31,8 +31,6 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.util.PropertyUtil;
 import org.immutables.value.Value;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableCache.java
@@ -23,12 +23,17 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Ticker;
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.util.PropertyUtil;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -81,9 +86,13 @@ class RESTTableCache implements Closeable {
       String sessionId,
       TableIdentifier identifier,
       Supplier<BaseTable> tableSupplier,
-      String eTag) {
+      String eTag,
+      TableMetadata tableMetadata,
+      Map<String, String> tableConfig,
+      List<Credential> credentials) {
     tableCache.put(
-        SessionIdTableId.of(sessionId, identifier), TableWithETag.of(tableSupplier, eTag));
+        SessionIdTableId.of(sessionId, identifier),
+        TableWithETag.of(tableSupplier, eTag, tableMetadata, tableConfig, credentials));
   }
 
   public void invalidate(String sessionId, TableIdentifier identifier) {
@@ -122,8 +131,25 @@ class RESTTableCache implements Closeable {
 
     String eTag();
 
-    static TableWithETag of(Supplier<BaseTable> tableSupplier, String eTag) {
-      return ImmutableTableWithETag.builder().supplier(tableSupplier).eTag(eTag).build();
+    TableMetadata tableMetadata();
+
+    Map<String, String> tableConfig();
+
+    List<Credential> credentials();
+
+    static TableWithETag of(
+        Supplier<BaseTable> tableSupplier,
+        String eTag,
+        TableMetadata tableMetadata,
+        Map<String, String> tableConfig,
+        List<Credential> credentials) {
+      return ImmutableTableWithETag.builder()
+          .supplier(tableSupplier)
+          .eTag(eTag)
+          .tableMetadata(tableMetadata)
+          .putAllTableConfig(tableConfig)
+          .addAllCredentials(credentials)
+          .build();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -39,7 +39,6 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.http.HttpHeaders;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -48,6 +47,7 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.RESTException;
@@ -67,7 +67,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-  public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
+public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(
           ImmutableMap.of(

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -39,6 +39,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
 import org.apache.http.HttpHeaders;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
@@ -66,7 +67,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
-public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
+  public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(
           ImmutableMap.of(
@@ -569,6 +570,50 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
         .containsOnlyKeys(
             SessionIdTableId.of(DEFAULT_SESSION_CONTEXT.sessionId(), TABLE),
             SessionIdTableId.of(otherSessionContext.sessionId(), TABLE));
+  }
+
+  @Test
+  public void notModifiedResponseShouldUseCurrentContextForCollidingSessionIds() {
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+    Map<String, FileIO> fileIOByToken = Maps.newHashMap();
+
+    RESTSessionCatalog sessionCatalog =
+        new RESTSessionCatalog(
+            config -> adapter,
+            (context, properties) ->
+                fileIOByToken.computeIfAbsent(
+                    tokenForContext(context),
+                    token -> Mockito.mock(FileIO.class, "io-for-" + token)));
+    sessionCatalog.initialize("test_session_catalog", Map.of());
+
+    SessionContext contextWithOriginalCredentials =
+        new SessionContext("colliding_session_id", "user-a", Map.of("token", "token-a"), Map.of());
+    SessionContext contextWithDifferentCredentials =
+        new SessionContext("colliding_session_id", "user-b", Map.of("token", "token-b"), Map.of());
+
+    sessionCatalog.createNamespace(contextWithOriginalCredentials, TABLE.namespace());
+    sessionCatalog.buildTable(contextWithOriginalCredentials, TABLE, SCHEMA).create();
+
+    expectFullTableLoadForLoadTable(TABLE, adapter);
+    BaseTable tableWithOriginalCredentials =
+        (BaseTable) sessionCatalog.loadTable(contextWithOriginalCredentials, TABLE);
+
+    expectNotModifiedResponseForLoadTable(TABLE, adapter);
+    BaseTable tableWithCollidingSessionId =
+        (BaseTable) sessionCatalog.loadTable(contextWithDifferentCredentials, TABLE);
+
+    assertThat(fileIOByToken).containsKeys("token-a", "token-b");
+    assertThat(tableWithOriginalCredentials.io()).isSameAs(fileIOByToken.get("token-a"));
+    assertThat(tableWithCollidingSessionId.io()).isSameAs(fileIOByToken.get("token-b"));
+  }
+
+  private String tokenForContext(SessionContext context) {
+    Map<String, String> credentials = context.credentials();
+    if (credentials == null) {
+      return "no-credentials";
+    }
+
+    return credentials.getOrDefault("token", "missing-token");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
@@ -28,12 +28,16 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.FakeTicker;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -47,6 +51,9 @@ public class TestRESTTableCache {
       () ->
           new BaseTable(new TestTables.TestTableOperations(TABLE_NAME, temp.toFile()), TABLE_NAME);
   private static final String ETAG = "d7sa6das";
+  private static final Schema TABLE_SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+  private static final PartitionSpec TABLE_SPEC = PartitionSpec.unpartitioned();
   private static final Duration HALF_OF_TABLE_EXPIRATION =
       Duration.ofMillis(RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS_DEFAULT)
           .dividedBy(2);
@@ -272,6 +279,9 @@ public class TestRESTTableCache {
   }
 
   private TableMetadata tableMetadata(String tableName) {
-    return new TestTables.TestTableOperations(tableName, temp.toFile()).current();
+    String location = temp.resolve(tableName).toFile().toString();
+
+    return TableMetadata.newTableMetadata(
+        TABLE_SCHEMA, TABLE_SPEC, SortOrder.unsorted(), location, Map.of());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTTableCache.java
@@ -28,9 +28,11 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.util.FakeTicker;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -74,7 +76,14 @@ public class TestRESTTableCache {
   @Test
   public void basicPutAndGet() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.cache().asMap()).hasSize(1);
     assertThat(cache.cache().asMap())
@@ -89,7 +98,14 @@ public class TestRESTTableCache {
   @Test
   public void notFoundInCache() {
     RESTTableCache cache = new RESTTableCache(Map.of());
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.getIfPresent("some_id", TABLE_IDENTIFIER)).isNull();
     assertThat(cache.getIfPresent(SESSION_ID, TableIdentifier.of("ns", "other_table"))).isNull();
@@ -99,8 +115,22 @@ public class TestRESTTableCache {
   public void tableInMultipleSessions() {
     RESTTableCache cache = new RESTTableCache(Map.of());
     String otherSessionId = "sessionID2";
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(otherSessionId, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
+    cache.put(
+        otherSessionId,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.cache().asMap()).hasSize(2);
 
@@ -119,7 +149,15 @@ public class TestRESTTableCache {
     RESTTableCache cache = new RESTTableCache(Map.of());
     // Add more items than the max limit
     for (int i = 0; i < RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES_DEFAULT + 10; ++i) {
-      cache.put(SESSION_ID, TableIdentifier.of("ns", "tbl" + i), TABLE_SUPPLIER, ETAG);
+      TableIdentifier identifier = TableIdentifier.of("ns", "tbl" + i);
+      cache.put(
+          SESSION_ID,
+          identifier,
+          TABLE_SUPPLIER,
+          ETAG,
+          tableMetadata(identifier.name()),
+          Map.of(),
+          ImmutableList.of());
     }
     cache.cache().cleanUp();
 
@@ -132,8 +170,22 @@ public class TestRESTTableCache {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "1"));
     TableIdentifier otherTableIdentifier = TableIdentifier.of("ns", "other_table");
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
-    cache.put(SESSION_ID, otherTableIdentifier, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
+    cache.put(
+        SESSION_ID,
+        otherTableIdentifier,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(otherTableIdentifier.name()),
+        Map.of(),
+        ImmutableList.of());
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).hasSize(1);
@@ -145,7 +197,14 @@ public class TestRESTTableCache {
   public void cacheTurnedOff() {
     RESTTableCache cache =
         new RESTTableCache(Map.of(RESTCatalogProperties.TABLE_CACHE_MAX_ENTRIES, "0"));
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
     cache.cache().cleanUp();
 
     assertThat(cache.cache().asMap()).isEmpty();
@@ -155,7 +214,14 @@ public class TestRESTTableCache {
   public void entryExpires() {
     FakeTicker ticker = new FakeTicker();
     RESTTableCache cache = new RESTTableCache(Map.of(), ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     SessionIdTableId cacheKey = SessionIdTableId.of(SESSION_ID, TABLE_IDENTIFIER);
     assertThat(cache.cache().policy().expireAfterAccess()).isNotPresent();
@@ -188,7 +254,14 @@ public class TestRESTTableCache {
                 RESTCatalogProperties.TABLE_CACHE_EXPIRE_AFTER_WRITE_MS,
                 String.valueOf(expirationInterval.toMillis())),
             ticker);
-    cache.put(SESSION_ID, TABLE_IDENTIFIER, TABLE_SUPPLIER, ETAG);
+    cache.put(
+        SESSION_ID,
+        TABLE_IDENTIFIER,
+        TABLE_SUPPLIER,
+        ETAG,
+        tableMetadata(TABLE_NAME),
+        Map.of(),
+        ImmutableList.of());
 
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNotNull();
 
@@ -196,5 +269,9 @@ public class TestRESTTableCache {
     cache.cache().cleanUp();
 
     assertThat(cache.getIfPresent(SESSION_ID, TABLE_IDENTIFIER)).isNull();
+  }
+
+  private TableMetadata tableMetadata(String tableName) {
+    return new TestTables.TestTableOperations(tableName, temp.toFile()).current();
   }
 }


### PR DESCRIPTION
Freshness-aware loads were reusing cached `BaseTable`/FileIO across colliding session IDs and could store null metadata in cache tests.

- Changes
  - Cache entries now carry non-null table metadata/config/credentials so cached NOT_MODIFIED responses can recreate tables with the caller’s `SessionContext`.
  - NOT_MODIFIED code path rebuilds tables from cached payloads (no stale session state) while preserving cache semantics.
  - Tests build minimal `TableMetadata` for cache entries to avoid nulls.

- Example
```java
tableCache.put(
    context.sessionId(),
    ident,
    tableSupplier,
    eTag,
    TableMetadata.newTableMetadata(schema, spec, SortOrder.unsorted(), location, Map.of()),
    tableConf,
    credentials);

BaseTable table = tableWithCurrentContext(context, ident, cached);
```