### PR TITLE
Core: Support incremental changelog scan with deletes

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -64,6 +65,13 @@ class BaseIncrementalChangelogScan
     }
 
     Set<Long> changelogSnapshotIds = toSnapshotIds(changelogSnapshots);
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
+
+    List<ManifestFile> newDeleteManifests =
+        FluentIterable.from(changelogSnapshots)
+            .transformAndConcat(snapshot -> snapshot.deleteManifests(table().io()))
+            .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
+            .toList();
 
     Set<ManifestFile> newDataManifests =
         FluentIterable.from(changelogSnapshots)
@@ -72,7 +80,7 @@ class BaseIncrementalChangelogScan
             .toSet();
 
     ManifestGroup manifestGroup =
-        new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
+        new ManifestGroup(table().io(), newDataManifests, newDeleteManifests)
             .specsById(table().specs())
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
@@ -89,7 +97,11 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    return manifestGroup.plan(new CreateDataFileChangeTasks(changelogSnapshots));
+    CloseableIterable<ChangelogScanTask> dataFileChangeTasks =
+        manifestGroup.plan(new CreateDataFileChangeTasks(snapshotOrdinals));
+    CloseableIterable<ChangelogScanTask> deleteFileChangeTasks =
+        planDeleteFileChanges(changelogSnapshots, snapshotOrdinals);
+    return CloseableIterable.concat(ImmutableList.of(dataFileChangeTasks, deleteFileChangeTasks));
   }
 
   @Override
@@ -105,16 +117,94 @@ class BaseIncrementalChangelogScan
 
     for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(table(), toIdIncl, fromIdExcl)) {
       if (!snapshot.operation().equals(DataOperations.REPLACE)) {
-        if (!snapshot.deleteManifests(table().io()).isEmpty()) {
-          throw new UnsupportedOperationException(
-              "Delete files are currently not supported in changelog scans");
-        }
-
         changelogSnapshots.addFirst(snapshot);
       }
     }
 
     return changelogSnapshots;
+  }
+
+  private CloseableIterable<ChangelogScanTask> planDeleteFileChanges(
+      Deque<Snapshot> snapshots, Map<Long, Integer> snapshotOrdinals) {
+    Iterable<CloseableIterable<ChangelogScanTask>> changelogTasks =
+        FluentIterable.from(snapshots)
+            .transform(snapshot -> planDeleteFileChanges(snapshot, snapshotOrdinals));
+    return CloseableIterable.concat(changelogTasks);
+  }
+
+  private CloseableIterable<ChangelogScanTask> planDeleteFileChanges(
+      Snapshot snapshot, Map<Long, Integer> snapshotOrdinals) {
+    List<ManifestFile> snapshotDeleteManifests = snapshot.deleteManifests(table().io());
+    List<ManifestFile> addedDeleteManifests =
+        FluentIterable.from(snapshotDeleteManifests)
+            .filter(manifest -> manifest.snapshotId() == snapshot.snapshotId())
+            .toList();
+
+    if (addedDeleteManifests.isEmpty()) {
+      return CloseableIterable.empty();
+    }
+
+    List<ManifestFile> existingDeleteManifests =
+        FluentIterable.from(snapshotDeleteManifests)
+            .filter(manifest -> manifest.snapshotId() != snapshot.snapshotId())
+            .toList();
+
+    DeleteFileIndex addedDeletes =
+        DeleteFileIndex.builderFor(table().io(), addedDeleteManifests)
+            .specsById(table().specs())
+            .filterData(filter())
+            .caseSensitive(isCaseSensitive())
+            .build();
+
+    DeleteFileIndex existingDeletes =
+        DeleteFileIndex.builderFor(table().io(), existingDeleteManifests)
+            .specsById(table().specs())
+            .filterData(filter())
+            .caseSensitive(isCaseSensitive())
+            .build();
+
+    ManifestGroup dataManifestGroup =
+        new ManifestGroup(table().io(), snapshot.dataManifests(table().io()), ImmutableList.of())
+            .specsById(table().specs())
+            .caseSensitive(isCaseSensitive())
+            .select(scanColumns())
+            .filterData(filter())
+            .ignoreDeleted()
+            .columnsToKeepStats(columnsToKeepStats());
+
+    if (shouldIgnoreResiduals()) {
+      dataManifestGroup = dataManifestGroup.ignoreResiduals();
+    }
+
+    if (snapshot.dataManifests(table().io()).size() > 1 && shouldPlanWithExecutor()) {
+      dataManifestGroup = dataManifestGroup.planWith(planExecutor());
+    }
+
+    CloseableIterable<ChangelogScanTask> tasks =
+        dataManifestGroup.plan(
+            (entries, context) ->
+                CloseableIterable.transform(
+                    entries,
+                    entry -> {
+                      DeleteFile[] addedDeleteFiles = addedDeletes.forEntry(entry);
+                      if (addedDeleteFiles.length == 0) {
+                        return null;
+                      }
+
+                      DeleteFile[] existingDeleteFiles = existingDeletes.forEntry(entry);
+                      DataFile dataFile = entry.file().copy(context.shouldKeepStats());
+                      return new BaseDeletedRowsScanTask(
+                          snapshotOrdinals.get(snapshot.snapshotId()),
+                          snapshot.snapshotId(),
+                          dataFile,
+                          addedDeleteFiles,
+                          existingDeleteFiles,
+                          context.schemaAsString(),
+                          context.specAsString(),
+                          context.residuals());
+                    }));
+
+    return CloseableIterable.filter(tasks, task -> task != null);
   }
 
   private Set<Long> toSnapshotIds(Collection<Snapshot> snapshots) {
@@ -138,8 +228,8 @@ class BaseIncrementalChangelogScan
 
     private final Map<Long, Integer> snapshotOrdinals;
 
-    CreateDataFileChangeTasks(Deque<Snapshot> snapshots) {
-      this.snapshotOrdinals = computeSnapshotOrdinals(snapshots);
+    CreateDataFileChangeTasks(Map<Long, Integer> snapshotOrdinals) {
+      this.snapshotOrdinals = snapshotOrdinals;
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -248,16 +247,35 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
-  public void testDeleteFilesAreNotSupported() {
+  public void testDeleteFiles() {
     assumeThat(formatVersion).isEqualTo(2);
 
     table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
 
+    Snapshot appendSnapshot = table.currentSnapshot();
+
     table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
 
-    assertThatThrownBy(() -> plan(newScan()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Delete files are currently not supported in changelog scans");
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan()
+            .fromSnapshotExclusive(appendSnapshot.snapshotId())
+            .toSnapshot(deleteSnapshot.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task.commitSnapshotId())
+        .as("Snapshot must match")
+        .isEqualTo(deleteSnapshot.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task.addedDeletes())
+        .as("Must include one added delete file")
+        .containsExactly(FILE_A2_DELETES);
+    assertThat(task.existingDeletes()).as("Must be no existing deletes").isEmpty();
   }
 
   // plans tasks and reorders them to have deterministic order


### PR DESCRIPTION
### Motivation
- Incremental changelog scans failed when snapshots contained delete manifests, preventing changelog output for deletes; the change enables changelog scans to include delete-file changes.
- Ensure change ordinals are assigned consistently across data-file and delete-file changelog tasks so downstream readers get stable metadata.

### Description
- Include delete manifests when building the `ManifestGroup` for changelog planning so delete-file context is available during data-file planning by calling `new ManifestGroup(..., newDeleteManifests)`.
- Compute a shared snapshot-ordinal map via `computeSnapshotOrdinals` and pass it into data-file task creation so ordinals are consistent across task types (`CreateDataFileChangeTasks` now accepts the ordinals map).
- Add delete-file planning via `planDeleteFileChanges(...)` that, per snapshot, builds `DeleteFileIndex` instances for added vs existing delete manifests and emits `BaseDeletedRowsScanTask` only for data files affected by newly added delete files.
- Remove the previous early `UnsupportedOperationException` for delete manifests and update `TestBaseIncrementalChangelogScan` to assert the expected `DeletedRowsScanTask` contents when delete files are added.

### Testing
- Ran `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestBaseIncrementalChangelogScan` (default JDK), which failed because the environment JDK was unsupported for the build (JDK 25 vs required JDK 17/21).
- Re-ran with JDK 17 using `JAVA_HOME=/root/.local/share/mise/installs/java/17 PATH=/root/.local/share/mise/installs/java/17/bin:$PATH ./gradlew :iceberg-core:test --tests org.apache.iceberg.TestBaseIncrementalChangelogScan`, which failed to complete due to external dependency resolution errors (Maven Central returned HTTP 403 while resolving artifacts).
- Unit test `TestBaseIncrementalChangelogScan` was updated to validate delete-file changelog planning and would exercise the new behavior when the test suite can be executed successfully in CI or a developer environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0aebc2efc8330b140df9e13989fe6)