### PR TITLE
Core: Recreate shared lock scheduler when shut down

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -159,15 +159,17 @@ public class LockManagers {
 
     @Override
     public void close() throws Exception {
-      if (scheduler != null) {
-        List<Runnable> tasks = scheduler.shutdownNow();
-        tasks.forEach(
-            task -> {
-              if (task instanceof Future) {
-                ((Future<?>) task).cancel(true);
-              }
-            });
-        scheduler = null;
+      synchronized (BaseLockManager.class) {
+        if (scheduler != null) {
+          List<Runnable> tasks = scheduler.shutdownNow();
+          tasks.forEach(
+              task -> {
+                if (task instanceof Future) {
+                  ((Future<?>) task).cancel(true);
+                }
+              });
+          scheduler = null;
+        }
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -109,9 +109,9 @@ public class LockManagers {
     }
 
     public ScheduledExecutorService scheduler() {
-      if (scheduler == null) {
+      if (scheduler == null || scheduler.isShutdown()) {
         synchronized (BaseLockManager.class) {
-          if (scheduler == null) {
+          if (scheduler == null || scheduler.isShutdown()) {
             scheduler =
                 MoreExecutors.getExitingScheduledExecutorService(
                     (ScheduledThreadPoolExecutor)


### PR DESCRIPTION
### Motivation
- The in-memory `LockManagers` uses a static shared `scheduler` that can be shut down by one instance and later reused by another, which leads to `RejectedExecutionException` when scheduling lock heartbeats (observed in Flink sink commit failures).

### Description
- Update `BaseLockManager.scheduler()` to recreate the shared `scheduler` when it is `null` or `isShutdown()`, applying the `isShutdown()` check both before and inside the synchronized initialization block so a terminated executor is not reused.

### Testing
- Ran targeted unit tests with `./gradlew :iceberg-core:test --tests org.apache.iceberg.util.TestInMemoryLockManager --tests org.apache.iceberg.util.TestLockManagers`, which failed initially due to the environment using JDK 25 while the build requires JDK 17 or 21, and a follow-up run with `JAVA_HOME` set to JDK 21 could not complete because Maven fetches failed with HTTP 403, so tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e794941d5083309aa51e993435ea55)