### PR TITLE
Plan deleted-row changelog tasks and add RowIdDeleteIndex (v3 DV support)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -21,7 +21,9 @@ package org.apache.iceberg;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestGroup.CreateTasksFunction;
@@ -63,10 +65,41 @@ class BaseIncrementalChangelogScan
       return CloseableIterable.empty();
     }
 
-    Set<Long> changelogSnapshotIds = toSnapshotIds(changelogSnapshots);
+    CloseableIterable<ChangelogScanTask> dataFileTasks = planDataFileTasks(changelogSnapshots);
+    CloseableIterable<ChangelogScanTask> deletedRowsTasks =
+        planDeletedRowsTasks(changelogSnapshots);
+    return CloseableIterable.concat(ImmutableList.of(dataFileTasks, deletedRowsTasks));
+  }
+
+  @Override
+  public CloseableIterable<ScanTaskGroup<ChangelogScanTask>> planTasks() {
+    return TableScanUtil.planTaskGroups(
+        planFiles(), targetSplitSize(), splitLookback(), splitOpenFileCost());
+  }
+
+  // builds a collection of changelog snapshots (oldest to newest)
+  // the order of the snapshots is important as it is used to determine change ordinals
+  private Deque<Snapshot> orderedChangelogSnapshots(Long fromIdExcl, long toIdIncl) {
+    Deque<Snapshot> changelogSnapshots = new ArrayDeque<>();
+
+    for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(table(), toIdIncl, fromIdExcl)) {
+      if (!snapshot.operation().equals(DataOperations.REPLACE)) {
+        changelogSnapshots.addFirst(snapshot);
+      }
+    }
+
+    return changelogSnapshots;
+  }
+
+  private Set<Long> toSnapshotIds(Collection<Snapshot> snapshots) {
+    return snapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+  }
+
+  private CloseableIterable<ChangelogScanTask> planDataFileTasks(Deque<Snapshot> snapshots) {
+    Set<Long> changelogSnapshotIds = toSnapshotIds(snapshots);
 
     Set<ManifestFile> newDataManifests =
-        FluentIterable.from(changelogSnapshots)
+        FluentIterable.from(snapshots)
             .transformAndConcat(snapshot -> snapshot.dataManifests(table().io()))
             .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
             .toSet();
@@ -89,36 +122,109 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    return manifestGroup.plan(new CreateDataFileChangeTasks(changelogSnapshots));
+    return manifestGroup.plan(new CreateDataFileChangeTasks(snapshots));
   }
 
-  @Override
-  public CloseableIterable<ScanTaskGroup<ChangelogScanTask>> planTasks() {
-    return TableScanUtil.planTaskGroups(
-        planFiles(), targetSplitSize(), splitLookback(), splitOpenFileCost());
-  }
+  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(Deque<Snapshot> snapshots) {
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(snapshots);
+    ImmutableList.Builder<CloseableIterable<ChangelogScanTask>> snapshotTasks =
+        ImmutableList.builder();
 
-  // builds a collection of changelog snapshots (oldest to newest)
-  // the order of the snapshots is important as it is used to determine change ordinals
-  private Deque<Snapshot> orderedChangelogSnapshots(Long fromIdExcl, long toIdIncl) {
-    Deque<Snapshot> changelogSnapshots = new ArrayDeque<>();
-
-    for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(table(), toIdIncl, fromIdExcl)) {
-      if (!snapshot.operation().equals(DataOperations.REPLACE)) {
-        if (!snapshot.deleteManifests(table().io()).isEmpty()) {
-          throw new UnsupportedOperationException(
-              "Delete files are currently not supported in changelog scans");
-        }
-
-        changelogSnapshots.addFirst(snapshot);
+    for (Snapshot snapshot : snapshots) {
+      List<ManifestFile> deleteManifests = snapshot.deleteManifests(table().io());
+      if (deleteManifests.isEmpty()) {
+        continue;
       }
+
+      SnapshotChanges.Builder changesBuilder =
+          SnapshotChanges.builderFor(snapshot, table().io(), table().specs());
+      if (shouldPlanWithExecutor()) {
+        changesBuilder.executeWith(planExecutor());
+      }
+
+      DeleteFileIndex addedDeletes =
+          DeleteFileIndex.builderFor(changesBuilder.build().addedDeleteFiles())
+              .specsById(table().specs())
+              .build();
+
+      if (addedDeletes.isEmpty()) {
+        continue;
+      }
+
+      RowIdDeleteIndex rowIdDeletes = null;
+      if (table().formatVersion() >= 3) {
+        rowIdDeletes = RowIdDeleteIndex.fromDeleteFiles(addedDeletes.referencedDeleteFiles());
+        if (rowIdDeletes.isEmpty()) {
+          continue;
+        }
+      }
+
+      DeleteFileIndex existingDeletes = existingDeletesIndex(snapshot);
+
+      ManifestGroup manifestGroup =
+          new ManifestGroup(table().io(), snapshot.dataManifests(table().io()), ImmutableList.of())
+              .specsById(table().specs())
+              .caseSensitive(isCaseSensitive())
+              .select(scanColumns())
+              .filterData(filter())
+              .ignoreDeleted()
+              .columnsToKeepStats(columnsToKeepStats());
+
+      if (table().formatVersion() >= 3) {
+        Set<String> referencedDataFiles = rowIdDeletes.referencedDataFiles();
+        manifestGroup =
+            manifestGroup.filterManifestEntries(
+                entry -> referencedDataFiles.contains(entry.file().location().toString()));
+      }
+
+      if (shouldIgnoreResiduals()) {
+        manifestGroup = manifestGroup.ignoreResiduals();
+      }
+
+      if (shouldPlanWithExecutor()) {
+        manifestGroup = manifestGroup.planWith(planExecutor());
+      }
+
+      int changeOrdinal = snapshotOrdinals.get(snapshot.snapshotId());
+      snapshotTasks.add(
+          manifestGroup.plan(
+              new CreateDeletedRowsTasks(
+                  changeOrdinal,
+                  snapshot.snapshotId(),
+                  existingDeletes,
+                  addedDeletes,
+                  rowIdDeletes)));
     }
 
-    return changelogSnapshots;
+    return CloseableIterable.concat(snapshotTasks.build());
   }
 
-  private Set<Long> toSnapshotIds(Collection<Snapshot> snapshots) {
-    return snapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
+  private DeleteFileIndex existingDeletesIndex(Snapshot snapshot) {
+    Long parentSnapshotId = snapshot.parentId();
+    if (parentSnapshotId == null) {
+      return DeleteFileIndex.builderFor(ImmutableList.of()).specsById(table().specs()).build();
+    }
+
+    Snapshot parentSnapshot = table().snapshot(parentSnapshotId);
+    if (parentSnapshot == null) {
+      return DeleteFileIndex.builderFor(ImmutableList.of()).specsById(table().specs()).build();
+    }
+
+    DeleteFileIndex.Builder builder =
+        DeleteFileIndex.builderFor(table().io(), parentSnapshot.deleteManifests(table().io()))
+            .specsById(table().specs())
+            .caseSensitive(isCaseSensitive())
+            .filterData(filter());
+
+    if (shouldPlanWithExecutor()) {
+      builder = builder.planWith(planExecutor());
+    }
+
+    if (shouldIgnoreResiduals()) {
+      builder = builder.ignoreResiduals();
+    }
+
+    return builder.build();
   }
 
   private static Map<Long, Integer> computeSnapshotOrdinals(Deque<Snapshot> snapshots) {
@@ -178,6 +284,58 @@ class BaseIncrementalChangelogScan
                 throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
             }
           });
+    }
+  }
+
+  private static class CreateDeletedRowsTasks implements CreateTasksFunction<ChangelogScanTask> {
+    private final int changeOrdinal;
+    private final long commitSnapshotId;
+    private final DeleteFileIndex existingDeleteIndex;
+    private final DeleteFileIndex addedDeleteIndex;
+    private final RowIdDeleteIndex rowIdDeleteIndex;
+
+    CreateDeletedRowsTasks(
+        int changeOrdinal,
+        long commitSnapshotId,
+        DeleteFileIndex existingDeleteIndex,
+        DeleteFileIndex addedDeleteIndex,
+        RowIdDeleteIndex rowIdDeleteIndex) {
+      this.changeOrdinal = changeOrdinal;
+      this.commitSnapshotId = commitSnapshotId;
+      this.existingDeleteIndex = existingDeleteIndex;
+      this.addedDeleteIndex = addedDeleteIndex;
+      this.rowIdDeleteIndex = rowIdDeleteIndex;
+    }
+
+    @Override
+    public CloseableIterable<ChangelogScanTask> apply(
+        CloseableIterable<ManifestEntry<DataFile>> entries, TaskContext context) {
+      CloseableIterable<ChangelogScanTask> tasks =
+          CloseableIterable.transform(
+              entries,
+              entry -> {
+                DeleteFile[] addedDeletes =
+                    rowIdDeleteIndex != null
+                        ? rowIdDeleteIndex.forDataFile(entry.file())
+                        : addedDeleteIndex.forEntry(entry);
+                if (addedDeletes.length == 0) {
+                  return null;
+                }
+
+                DeleteFile[] existingDeletes = existingDeleteIndex.forEntry(entry);
+                DataFile dataFile = entry.file().copy(context.shouldKeepStats());
+                return new BaseDeletedRowsScanTask(
+                    changeOrdinal,
+                    commitSnapshotId,
+                    dataFile,
+                    addedDeletes,
+                    existingDeletes,
+                    context.schemaAsString(),
+                    context.specAsString(),
+                    context.residuals());
+              });
+
+      return CloseableIterable.filter(tasks, Objects::nonNull);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/RowIdDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/RowIdDeleteIndex.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ContentFileUtil;
+
+class RowIdDeleteIndex {
+  private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
+
+  private final Map<String, List<DeleteFile>> dvByDataFile;
+
+  private RowIdDeleteIndex(Map<String, List<DeleteFile>> dvByDataFile) {
+    this.dvByDataFile = dvByDataFile;
+  }
+
+  static RowIdDeleteIndex fromDeleteFiles(Iterable<DeleteFile> deleteFiles) {
+    Map<String, List<DeleteFile>> dvs = Maps.newHashMap();
+
+    for (DeleteFile deleteFile : deleteFiles) {
+      if (!ContentFileUtil.isDV(deleteFile)) {
+        continue;
+      }
+
+      String referencedDataFile = ContentFileUtil.referencedDataFileLocation(deleteFile);
+      if (referencedDataFile == null) {
+        continue;
+      }
+
+      dvs.computeIfAbsent(referencedDataFile, ignored -> Lists.newArrayList()).add(deleteFile);
+    }
+
+    Map<String, List<DeleteFile>> immutableDvs = Maps.newHashMapWithExpectedSize(dvs.size());
+    dvs.forEach((path, files) -> immutableDvs.put(path, ImmutableList.copyOf(files)));
+    return new RowIdDeleteIndex(immutableDvs);
+  }
+
+  boolean isEmpty() {
+    return dvByDataFile.isEmpty();
+  }
+
+  Set<String> referencedDataFiles() {
+    return dvByDataFile.keySet();
+  }
+
+  DeleteFile[] forDataFile(DataFile dataFile) {
+    if (dataFile.firstRowId() == null) {
+      return NO_DELETES;
+    }
+
+    List<DeleteFile> deleteFiles = dvByDataFile.get(dataFile.location().toString());
+    return deleteFiles != null ? deleteFiles.toArray(new DeleteFile[0]) : NO_DELETES;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -248,16 +247,99 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
-  public void testDeleteFilesAreNotSupported() {
+  public void testDeleteFilesProduceDeletedRowsTasks() {
     assumeThat(formatVersion).isEqualTo(2);
 
-    table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    Snapshot appendSnapshot = table.currentSnapshot();
+
+    table.newRowDelta().addDeletes(FILE_A_EQUALITY_DELETES).commit();
+
+    Snapshot firstDeleteSnapshot = table.currentSnapshot();
 
     table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
 
-    assertThatThrownBy(() -> plan(newScan()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Delete files are currently not supported in changelog scans");
+    Snapshot secondDeleteSnapshot = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan()
+            .fromSnapshotExclusive(appendSnapshot.snapshotId())
+            .toSnapshot(secondDeleteSnapshot.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 2 delete row tasks").hasSize(2);
+
+    DeletedRowsScanTask firstTask = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(firstTask.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(firstTask.commitSnapshotId())
+        .as("Snapshot must match")
+        .isEqualTo(firstDeleteSnapshot.snapshotId());
+    assertThat(firstTask.file().location())
+        .as("Data file must match")
+        .isEqualTo(FILE_A.location());
+    assertThat(firstTask.existingDeletes()).as("Must be no existing deletes").isEmpty();
+    assertThat(firstTask.addedDeletes())
+        .as("Must include added deletes")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_EQUALITY_DELETES.location());
+
+    DeletedRowsScanTask secondTask = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(secondTask.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(secondTask.commitSnapshotId())
+        .as("Snapshot must match")
+        .isEqualTo(secondDeleteSnapshot.snapshotId());
+    assertThat(secondTask.file().location())
+        .as("Data file must match")
+        .isEqualTo(FILE_A.location());
+    assertThat(secondTask.existingDeletes())
+        .as("Must include existing deletes")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_EQUALITY_DELETES.location());
+    assertThat(secondTask.addedDeletes())
+        .as("Must include added deletes")
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+
+    assertThat(tasks)
+        .as("All tasks must be deleted rows tasks")
+        .allMatch(task -> task instanceof DeletedRowsScanTask);
+  }
+
+  @TestTemplate
+  public void testDvDeleteFilesProduceDeletedRowsTasks() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    Snapshot appendSnapshot = table.currentSnapshot();
+
+    DeleteFile fileDeletes = fileADeletes();
+    table.newRowDelta().addDeletes(fileDeletes).commit();
+
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan()
+            .fromSnapshotExclusive(appendSnapshot.snapshotId())
+            .toSnapshot(deleteSnapshot.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).as("Must have 1 delete row task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task.commitSnapshotId())
+        .as("Snapshot must match")
+        .isEqualTo(deleteSnapshot.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes()).as("Must be no existing deletes").isEmpty();
+    assertThat(task.addedDeletes())
+        .as("Must include added deletes")
+        .extracting(DeleteFile::location)
+        .containsExactly(fileDeletes.location());
   }
 
   // plans tasks and reorders them to have deterministic order

--- a/docs/docs/row-id-delete-index-prototype.md
+++ b/docs/docs/row-id-delete-index-prototype.md
@@ -1,0 +1,113 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Row-ID Delete Delta Index (Prototype Plan)
+
+This document sketches a minimal prototype for reducing incremental changelog planning cost by
+materializing deleted row IDs per snapshot.
+
+## Goals
+
+- Work first for **format v3+ tables** with row lineage.
+- Preserve existing changelog semantics (`changeOrdinal`, `commitSnapshotId`).
+- Preserve compatibility with current `DeletedRowsScanTask` behavior.
+- Avoid API breakage and keep fallback to existing delete planning.
+
+## Non-goals
+
+- Changing table format semantics in the first prototype.
+- Replacing all delete planning paths at once.
+- Supporting equality deletes in the initial milestone.
+
+## Why this is viable
+
+- Row lineage metadata already exists (`_row_id`, `_last_updated_sequence_number`).
+- Snapshot metadata already exposes row lineage fields (`firstRowId`, `addedRows`).
+- Current changelog delete planning is snapshot-based and can swap in an alternative source for
+  row-level delete deltas while preserving task ordering.
+
+## Prototype data model
+
+Introduce an internal, snapshot-scoped sidecar artifact:
+
+`row-delete-delta-<snapshot-id>.avro`
+
+Fields:
+
+- `snapshot_id` (long)
+- `parent_snapshot_id` (long)
+- `referenced_data_file` (string)
+- `delete_file_path` (string)
+- `deleted_row_ids` (binary, compressed bitmap)
+- `deleted_row_count` (long)
+
+The sidecar stores only row IDs deleted by that snapshot (delta, not cumulative state).
+
+## Commit-time update protocol
+
+For each committed snapshot `S` that adds delete vectors:
+
+1. Collect added DVs in `S`.
+2. Resolve referenced data files (DV => referenced data path).
+3. For each referenced file:
+   - translate deleted row positions to row IDs using `first_row_id + position`.
+   - write compressed row-ID bitmap into the sidecar record.
+4. Publish sidecar location in snapshot summary metadata.
+
+### Failure and atomicity
+
+- Sidecar is written before snapshot commit finalization.
+- Snapshot reference to sidecar is atomic with snapshot publication.
+- On sidecar read failure, planner falls back to current delete-index path.
+
+## Read-time protocol (incremental changelog)
+
+Given `(fromSnapshotExclusive, toSnapshotInclusive)`:
+
+1. Build ordered changelog snapshots and ordinals.
+2. For each snapshot `S` in range:
+   - if a sidecar is present, load deleted row-ID deltas from sidecar;
+   - build deleted-row changelog tasks from referenced data files;
+   - assign `changeOrdinal` and `commitSnapshotId` exactly as today.
+3. If sidecar is absent/unreadable, use existing `DeleteFileIndex` planning path.
+
+## Rollout plan
+
+### Phase 1 (MVP)
+
+- v3+ only, DV-only input.
+- sidecar write/read behind a table property flag (default off).
+- fallback enabled by default.
+
+### Phase 2
+
+- Include position deletes in v2/v3 tables.
+- support mixed delete types by materializing row-ID deltas.
+
+### Phase 3
+
+- Optional cumulative compaction artifacts (prefix snapshots) for faster long-range planning.
+- optional engine-specific reader optimizations that consume row-ID bitmaps directly.
+
+## Validation plan
+
+- Unit tests for sidecar write/read and fallback behavior.
+- Incremental changelog determinism tests for ordinals and snapshot IDs.
+- Cross-branch correctness tests (branch-local snapshots and sidecar references).
+- Fault-injection tests (missing/corrupt sidecar should not change correctness).


### PR DESCRIPTION
### Motivation

- Enable incremental changelog scans to produce `DeletedRowsScanTask` entries for snapshots that add delete files instead of failing or ignoring them. 
- Reduce cost and improve correctness for format v3 row-vector (DV) deletes by using a row-id based index when available. 
- Keep existing added-data planning semantics while adding a separate path for delete planning and provide a documented prototype for row-id delta sidecars.

### Description

- Refactors `BaseIncrementalChangelogScan` to split planning into `planDataFileTasks` and `planDeletedRowsTasks`, to build ordered changelog snapshots, compute snapshot ordinals, and to return concatenated changelog tasks. 
- Adds a new `CreateDeletedRowsTasks` `CreateTasksFunction` implementation that builds `DeletedRowsScanTask` instances by combining added delete files, existing deletes from the parent snapshot, and optional `RowIdDeleteIndex` lookups. 
- Implements `existingDeletesIndex(...)` to index parent-snapshot delete manifests and uses `DeleteFileIndex`/`RowIdDeleteIndex` to resolve added and existing deletes, with format v3 DV optimization via `RowIdDeleteIndex`. 
- Introduces `RowIdDeleteIndex` class that groups DV delete files by referenced data file and can produce delete arrays for a given `DataFile`, plus a new docs prototype `docs/docs/row-id-delete-index-prototype.md` describing the design and rollout plan. 
- Updates `CreateDataFileChangeTasks` to use snapshot ordinals computed from the ordered snapshots, and exposes `planTasks()` to return grouped `ScanTaskGroup<ChangelogScanTask>` results.

### Testing

- Ran modified unit tests in `TestBaseIncrementalChangelogScan`, including the updated `testDeleteFilesProduceDeletedRowsTasks` and `testDvDeleteFilesProduceDeletedRowsTasks`, and they passed. 
- Executed the core module unit tests that cover changelog planning paths and delete-index behavior, and they succeeded locally. 
- No automated test failures were observed for the changed planning paths after the updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e88910af8883308da80e76399e760b)