### PR TITLE
CI: Add PR title check workflow

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -19,7 +19,7 @@ name: PR Title Check
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened]
 
 permissions:
   contents: read

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -34,9 +34,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^[A-Za-z][A-Za-z0-9 ._+/&-]*: .+'
-
-          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+          if ! echo $PR_TITLE | grep -Eq '^[A-Za-z][A-Za-z0-9 ._+/&-]*: .+'; then
             echo "Invalid PR title: '$PR_TITLE'"
             echo "PR titles must follow 'Module: Description' (example: 'Core: Fix manifest reuse in scan planning')."
             exit 1

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -30,7 +30,7 @@ jobs:
     name: Validate PR title format
     runs-on: ubuntu-latest
     steps:
-      - name: Validate title follows "Module: Description"
+      - name: Validate PR Title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^[A-Za-z][A-Za-z0-9 ._+\-/&]*: .+'
+          pattern='^[A-Za-z][A-Za-z0-9 ._+/&-]*: .+'
 
           if [[ ! "$PR_TITLE" =~ $pattern ]]; then
             echo "Invalid PR title: '$PR_TITLE'"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: PR Title Check
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pr-title:
+    name: Validate PR title format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate title follows "Module: Description"
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^[A-Za-z][A-Za-z0-9 ._+\-/&]*: .+'
+
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "Invalid PR title: '$PR_TITLE'"
+            echo "PR titles must follow 'Module: Description' (example: 'Core: Fix manifest reuse in scan planning')."
+            exit 1
+          fi
+
+          echo "PR title is valid: '$PR_TITLE'"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@
 name: PR Title Check
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened]
 
 permissions:


### PR DESCRIPTION
### Motivation
- Enforce the repository PR title convention and fail early when titles do not follow the `Module: Description` format.

### Description
- Add `​.github/workflows/pr-title-check.yml` that runs on `pull_request_target` (`opened`, `edited`, `reopened`, `synchronize`), uses minimal `contents: read` and `pull-requests: read` permissions, and validates `github.event.pull_request.title` against the regex `^[A-Za-z][A-Za-z0-9 ._+\-/&]*: .+`, exiting non-zero with an actionable message on mismatch.

### Testing
- No automated test suite was executed; the workflow file was added and its contents, including the regex and shell check, were reviewed locally for correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0caaf120833081b64dc31b66cb02)