### PR TITLE
Make PR title validation portable by using grep -E instead of Bash regex

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           pattern='^[A-Za-z][A-Za-z0-9 ._+/&-]*: .+'
 
-          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+          if ! printf '%s\n' "$PR_TITLE" | grep -Eq "$pattern"; then
             echo "Invalid PR title: '$PR_TITLE'"
             echo "PR titles must follow 'Module: Description' (example: 'Core: Fix manifest reuse in scan planning')."
             exit 1


### PR DESCRIPTION
### Motivation
- Ensure the PR title validation step in the GitHub Actions workflow is portable to shells that don't support Bash's `[[ ... =~ ... ]]` operator by using `grep -Eq` instead.

### Description
- Replace the Bash regex test `if [[ ! "$PR_TITLE" =~ $pattern ]]; then` with a portable `if ! printf '%s\n' "$PR_TITLE" | grep -Eq "$pattern"; then` in `.github/workflows/pr-title-check.yml`.

### Testing
- No automated tests were run for this change; the modification is a small portability fix to the CI workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb143f74208330b30bfa956906d660)