### PR TITLE
CI: Scope Spark CI to changed Spark versions

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -73,7 +73,103 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  spark-test-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      spark-versions-json: ${{ steps.detect.outputs.spark-versions-json }}
+      spark-versions: ${{ steps.detect.outputs.spark-versions }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect Spark versions to test
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+
+          all_versions=("3.5" "4.0" "4.1")
+          selected_versions=()
+          run_all=false
+          spark_workflow=".github/workflows/spark-ci.yml"
+
+          add_version_for_path() {
+            for version in "${all_versions[@]}"; do
+              if [[ "$1" == "spark/v${version}/"* ]]; then
+                select_version "${version}"
+                return 0
+              fi
+            done
+
+            return 1
+          }
+
+          select_version() {
+            if [[ "${#selected_versions[@]}" -gt 0 ]]; then
+              for selected_version in "${selected_versions[@]}"; do
+                if [[ "${selected_version}" == "$1" ]]; then
+                  return
+                fi
+              done
+            fi
+
+            selected_versions+=("$1")
+          }
+
+          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+            run_all=true
+          elif [[ -z "${BASE_SHA}" ]]; then
+            echo "Missing pull request base SHA" >&2
+            exit 1
+          else
+            while IFS= read -r changed_file; do
+              if [[ -z "${changed_file}" ]]; then
+                continue
+              fi
+
+              # Ignore this workflow when paired with version-scoped Spark changes.
+              if [[ "${changed_file}" == "${spark_workflow}" ]]; then
+                continue
+              fi
+
+              # Only exclusively version-scoped Spark changes narrow the matrix.
+              # Shared or unknown paths keep the full Spark test matrix.
+              if ! add_version_for_path "${changed_file}"; then
+                run_all=true
+                break
+              fi
+            done < <(git diff --name-only "${BASE_SHA}...HEAD")
+          fi
+
+          selected=()
+          if [[ "${run_all}" == "true" ]]; then
+            selected=("${all_versions[@]}")
+          else
+            for version in "${all_versions[@]}"; do
+              if [[ "${#selected_versions[@]}" -gt 0 ]]; then
+                for selected_version in "${selected_versions[@]}"; do
+                  if [[ "${selected_version}" == "${version}" ]]; then
+                    selected+=("${version}")
+                  fi
+                done
+              fi
+            done
+
+            if [[ "${#selected[@]}" -eq 0 ]]; then
+              selected=("${all_versions[@]}")
+            fi
+          fi
+
+          selected_json=$(printf '%s\n' "${selected[@]}" | jq -R . | jq -cs .)
+
+          echo "spark-versions-json=${selected_json}" >> "${GITHUB_OUTPUT}"
+          echo "spark-versions=${selected[*]}" >> "${GITHUB_OUTPUT}"
+          echo "Spark versions selected for CI: ${selected[*]}" >> "${GITHUB_STEP_SUMMARY}"
+
   spark-tests:
+    needs: spark-test-matrix
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -82,7 +178,7 @@ jobs:
       max-parallel: 20
       matrix:
         jvm: [17, 21]
-        spark: ['3.5', '4.0', '4.1']
+        spark: ${{ fromJson(needs.spark-test-matrix.outputs.spark-versions-json) }}
         scala: ['2.12', '2.13']
         # Split iceberg-spark (core) from iceberg-spark-extensions/-runtime
         # so they run as concurrent jobs rather than serially in one job.


### PR DESCRIPTION
## Which issue does this PR close?

N/A.

## Rationale for this change

Spark CI currently runs the full Spark matrix even when a pull request only changes files under a single version-specific Spark directory. That makes small Spark 4.1-only changes schedule Spark 3.5 and Spark 4.0 jobs unnecessarily.

## What changes are included in this PR?

- Adds a Spark CI detection job that builds the test matrix from changed paths.
- Keeps full Spark CI for pushes, shared Spark changes, unknown Spark-impacting paths, and workflow-only changes.
- Selects only the matching Spark version for paths under `spark/v3.5`, `spark/v4.0`, or `spark/v4.1`.
- Refines the detector to use merge-base diffing and to ignore the Spark workflow file when version-specific paths are also present.
- Updates a few Spark 4.1 JMH command examples to use the `4.1_2.13` project name.

## How are these changes tested?

- `git diff --check`
- `git diff --cached --check`
- Local execution of the extracted Spark CI detector for this branch's workflow plus `spark/v4.1` diff, which emitted `spark-versions=4.1` with four Spark 4.1 jobs: JVM 17/21 x core/extensions.

Note: live PR check inspection was not available from this checkout because the local `gh` token is invalid.