### PR TITLE
Core: Support changelog scans for deletion vectors

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -18,24 +18,19 @@
  */
 package org.apache.iceberg;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestGroup.CreateTasksFunction;
 import org.apache.iceberg.ManifestGroup.TaskContext;
-import org.apache.iceberg.expressions.Evaluator;
-import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.expressions.ManifestEvaluator;
-import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -43,23 +38,19 @@ import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.ContentFileUtil;
-import org.apache.iceberg.util.Pair;
-import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.TableScanUtil;
-import org.apache.iceberg.util.Tasks;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 class BaseIncrementalChangelogScan
     extends BaseIncrementalScan<
         IncrementalChangelogScan, ChangelogScanTask, ScanTaskGroup<ChangelogScanTask>>
     implements IncrementalChangelogScan {
 
-  private static final Logger LOG = LoggerFactory.getLogger(BaseIncrementalChangelogScan.class);
+  private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
+  private static final String UNSUPPORTED_DELETE_FILES_MESSAGE =
+      "Only deletion vectors in v3 tables are supported in changelog scans";
 
   BaseIncrementalChangelogScan(Table table) {
     this(table, table.schema(), TableScanContext.empty());
@@ -75,12 +66,6 @@ class BaseIncrementalChangelogScan
     return new BaseIncrementalChangelogScan(newTable, newSchema, newContext);
   }
 
-  // Private fields to track build call count and cache (accessed via package-private methods for
-  // testing)
-  private int existingDeleteIndexBuildCallCount = 0;
-  // Cache for the built index (null if not built yet)
-  private DeleteFileIndex cachedExistingDeleteIndex = null;
-
   @Override
   protected CloseableIterable<ChangelogScanTask> doPlanFiles(
       Long fromSnapshotIdExclusive, long toSnapshotIdInclusive) {
@@ -93,26 +78,14 @@ class BaseIncrementalChangelogScan
     }
 
     Set<Long> changelogSnapshotIds = toSnapshotIds(changelogSnapshots);
+    Map<String, DeleteFile> activeDVs = buildActiveDVs(beforeFirstSnapshotId(changelogSnapshots));
+    Map<Long, DeleteFileChanges> dvChangesBySnapshot = buildDVChangesBySnapshot(changelogSnapshots);
 
     Set<ManifestFile> newDataManifests =
         FluentIterable.from(changelogSnapshots)
             .transformAndConcat(snapshot -> snapshot.dataManifests(table().io()))
             .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
             .toSet();
-
-    // Build per-snapshot delete file indexes for added deletes
-    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = buildAddedDeleteIndexes(changelogSnapshots);
-
-    // Check if existing delete index is needed for equality deletes
-    boolean hasEqualityDeletes =
-        addedDeletesBySnapshot.values().stream()
-            .anyMatch(index -> !index.isEmpty() && index.hasEqualityDeletes());
-
-    // Build existing index early if needed for equality deletes, otherwise use lazy initialization
-    DeleteFileIndex existingDeleteIndex =
-        hasEqualityDeletes
-            ? buildExistingDeleteIndexTracked(fromSnapshotIdExclusive)
-            : DeleteFileIndex.emptyIndex();
 
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
@@ -132,36 +105,17 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    // Create a supplier that reuses already-built index or builds lazily when first DELETED entry
-    // is encountered
-    Supplier<DeleteFileIndex> existingDeleteIndexSupplier =
-        () -> {
-          if (cachedExistingDeleteIndex != null) {
-            return cachedExistingDeleteIndex;
-          }
-          return buildExistingDeleteIndexTracked(fromSnapshotIdExclusive);
-        };
-
-    // Plan data file tasks (ADDED and DELETED)
-    Map<Long, List<DeleteFile>> cumulativeDeletesMap =
-        buildCumulativeDeletesBySnapshot(changelogSnapshots, addedDeletesBySnapshot);
+    Map<Long, Map<String, DeleteFile>> activeDVsBySnapshot =
+        buildActiveDVsBySnapshot(changelogSnapshots, activeDVs, dvChangesBySnapshot);
 
     CloseableIterable<ChangelogScanTask> dataFileTasks =
         manifestGroup.plan(
             new CreateDataFileChangeTasks(
-                changelogSnapshots,
-                existingDeleteIndexSupplier,
-                addedDeletesBySnapshot,
-                cumulativeDeletesMap,
-                table().specs(),
-                isCaseSensitive()));
-
-    // Find EXISTING data files affected by newly added delete files and create tasks for them
+                changelogSnapshots, dvChangesBySnapshot, activeDVsBySnapshot));
     CloseableIterable<ChangelogScanTask> deletedRowsTasks =
         planDeletedRowsTasks(
-            changelogSnapshots, existingDeleteIndex, addedDeletesBySnapshot, changelogSnapshotIds);
+            changelogSnapshots, changelogSnapshotIds, activeDVs, dvChangesBySnapshot);
 
-    // Merge tasks from both iterables in order by changeOrdinal
     Comparator<ChangelogScanTask> byOrdinal =
         Comparator.comparing(ChangelogScanTask::changeOrdinal)
             .thenComparing(ChangelogScanTask::commitSnapshotId);
@@ -205,387 +159,205 @@ class BaseIncrementalChangelogScan
     return snapshotOrdinals;
   }
 
-  /**
-   * Builds a delete file index for existing deletes that were present before the start snapshot.
-   * These deletes should be applied to data files but should not generate DELETE changelog rows.
-   * Uses manifest pruning and caching to optimize performance.
-   */
-  private DeleteFileIndex buildExistingDeleteIndex(Long fromSnapshotIdExclusive) {
+  private Map<String, DeleteFile> buildActiveDVs(Long fromSnapshotIdExclusive) {
     if (fromSnapshotIdExclusive == null) {
-      return DeleteFileIndex.emptyIndex();
+      return Maps.newHashMap();
     }
+
     Snapshot fromSnapshot = table().snapshot(fromSnapshotIdExclusive);
     Preconditions.checkState(
         fromSnapshot != null, "Cannot find starting snapshot: %s", fromSnapshotIdExclusive);
 
-    List<ManifestFile> existingDeleteManifests = fromSnapshot.deleteManifests(table().io());
-    if (existingDeleteManifests.isEmpty()) {
-      return DeleteFileIndex.emptyIndex();
-    }
-
-    // Prune manifests based on partition filter to avoid processing irrelevant manifests
-    List<ManifestFile> prunedManifests = pruneManifestsByPartition(existingDeleteManifests);
-    if (prunedManifests.isEmpty()) {
-      return DeleteFileIndex.emptyIndex();
-    }
-
-    // Load delete files from manifests
-    Iterable<DeleteFile> deleteFiles = loadDeleteFiles(prunedManifests, null);
-
-    return DeleteFileIndex.builderFor(deleteFiles)
-        .specsById(table().specs())
-        .caseSensitive(isCaseSensitive())
-        .build();
-  }
-
-  /**
-   * Wrapper method that tracks build calls and caches the result for reuse. This ensures we only
-   * build the index once even if called from multiple places.
-   */
-  private DeleteFileIndex buildExistingDeleteIndexTracked(Long fromSnapshotIdExclusive) {
-    if (cachedExistingDeleteIndex != null) {
-      return cachedExistingDeleteIndex;
-    }
-    existingDeleteIndexBuildCallCount++;
-    cachedExistingDeleteIndex = buildExistingDeleteIndex(fromSnapshotIdExclusive);
-    return cachedExistingDeleteIndex;
-  }
-
-  // Visible for testing
-  int getExistingDeleteIndexBuildCallCount() {
-    return existingDeleteIndexBuildCallCount;
-  }
-
-  // Visible for testing
-  boolean wasExistingDeleteIndexBuilt() {
-    return existingDeleteIndexBuildCallCount > 0;
-  }
-
-  /**
-   * Builds per-snapshot delete file indexes for newly added delete files in each changelog
-   * snapshot. These deletes should generate DELETE changelog rows. Uses caching to avoid re-parsing
-   * manifests.
-   */
-  private Map<Long, DeleteFileIndex> buildAddedDeleteIndexes(Deque<Snapshot> changelogSnapshots) {
-    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = Maps.newConcurrentMap();
-    Tasks.foreach(changelogSnapshots)
-        .retry(3)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .onFailure(
-            (snapshot, exc) ->
-                LOG.warn(
-                    "Failed to build delete index for snapshot {}", snapshot.snapshotId(), exc))
-        .run(
-            snapshot -> {
-              List<ManifestFile> snapshotDeleteManifests = snapshot.deleteManifests(table().io());
-              if (snapshotDeleteManifests.isEmpty()) {
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
-                return;
-              }
-
-              // Filter to only include delete files added in this snapshot
-              List<ManifestFile> addedDeleteManifests =
-                  snapshotDeleteManifests.stream()
-                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
-                      .collect(Collectors.toUnmodifiableList());
-
-              if (addedDeleteManifests.isEmpty()) {
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
-              } else {
-                // Load delete files from manifests
-                Iterable<DeleteFile> deleteFiles =
-                    loadDeleteFiles(addedDeleteManifests, snapshot.snapshotId());
-
-                DeleteFileIndex index =
-                    DeleteFileIndex.builderFor(deleteFiles)
-                        .specsById(table().specs())
-                        .caseSensitive(isCaseSensitive())
-                        .build();
-                addedDeletesBySnapshot.put(snapshot.snapshotId(), index);
-              }
-            });
-    return addedDeletesBySnapshot;
-  }
-
-  /**
-   * Plans tasks for EXISTING data files that are affected by newly added delete files. These files
-   * were not added or deleted in the changelog snapshot range, but have new delete files applied to
-   * them.
-   */
-  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(
-      Deque<Snapshot> changelogSnapshots,
-      DeleteFileIndex existingDeleteIndex,
-      Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
-      Set<Long> changelogSnapshotIds) {
-
-    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
-    List<ChangelogScanTask> tasks = Lists.newArrayList();
-
-    // Build a map of file statuses and collect affected partitions for each snapshot
-    Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet> fileStatusAndPartitions =
-        buildFileStatusBySnapshot(changelogSnapshots, changelogSnapshotIds);
-    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot =
-        fileStatusAndPartitions.first();
-    PartitionSet affectedPartitions = fileStatusAndPartitions.second();
-
-    // Accumulate actual DeleteFile entries chronologically
-    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
-
-    // Start with deletes from before the changelog range
-    if (!existingDeleteIndex.isEmpty()) {
-      for (DeleteFile df : existingDeleteIndex.referencedDeleteFiles()) {
-        accumulatedDeletes.add(df);
+    Map<String, DeleteFile> activeDVs = Maps.newHashMap();
+    for (ManifestFile manifest : fromSnapshot.deleteManifests(table().io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+        for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+          if (entry.status() != ManifestEntry.Status.DELETED) {
+            DeleteFile dv = copySupportedDV(entry.file());
+            activeDVs.put(dv.referencedDataFile(), dv);
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to read delete manifest: " + manifest.path(), e);
       }
     }
 
+    return activeDVs;
+  }
+
+  private Map<Long, DeleteFileChanges> buildDVChangesBySnapshot(Deque<Snapshot> snapshots) {
+    Map<Long, DeleteFileChanges> changesBySnapshot = Maps.newHashMap();
+    for (Snapshot snapshot : snapshots) {
+      changesBySnapshot.put(snapshot.snapshotId(), loadDVChanges(snapshot));
+    }
+
+    return changesBySnapshot;
+  }
+
+  private DeleteFileChanges loadDVChanges(Snapshot snapshot) {
+    List<DeleteFile> addedDVs = Lists.newArrayList();
+    List<DeleteFile> removedDVs = Lists.newArrayList();
+
+    for (ManifestFile manifest : snapshot.deleteManifests(table().io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+        for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+          if (entry.snapshotId().equals(snapshot.snapshotId())) {
+            DeleteFile dv = copySupportedDV(entry.file());
+
+            if (entry.status() == ManifestEntry.Status.ADDED) {
+              addedDVs.add(dv);
+            } else if (entry.status() == ManifestEntry.Status.DELETED) {
+              removedDVs.add(dv);
+            }
+          }
+        }
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to read delete manifest: " + manifest.path(), e);
+      }
+    }
+
+    return new DeleteFileChanges(addedDVs, removedDVs);
+  }
+
+  private DeleteFile copySupportedDV(DeleteFile file) {
+    if (!isSupportedDV(file)) {
+      throw new UnsupportedOperationException(UNSUPPORTED_DELETE_FILES_MESSAGE);
+    }
+
+    return ContentFileUtil.copy(file, true, Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId()));
+  }
+
+  private boolean isSupportedDV(DeleteFile file) {
+    return TableUtil.formatVersion(table()) >= 3
+        && file.content() == FileContent.POSITION_DELETES
+        && ContentFileUtil.isDV(file);
+  }
+
+  private Map<Long, Map<String, DeleteFile>> buildActiveDVsBySnapshot(
+      Deque<Snapshot> snapshots,
+      Map<String, DeleteFile> activeDVs,
+      Map<Long, DeleteFileChanges> dvChangesBySnapshot) {
+    Map<Long, Map<String, DeleteFile>> activeDVsBySnapshot = Maps.newHashMap();
+    Map<String, DeleteFile> currentDVs = Maps.newHashMap(activeDVs);
+
+    for (Snapshot snapshot : snapshots) {
+      activeDVsBySnapshot.put(snapshot.snapshotId(), Maps.newHashMap(currentDVs));
+
+      DeleteFileChanges changes = dvChangesBySnapshot.get(snapshot.snapshotId());
+      for (DeleteFile removedDV : changes.removedDVs()) {
+        currentDVs.remove(removedDV.referencedDataFile());
+      }
+
+      for (DeleteFile addedDV : changes.addedDVs()) {
+        currentDVs.put(addedDV.referencedDataFile(), addedDV);
+      }
+    }
+
+    return activeDVsBySnapshot;
+  }
+
+  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(
+      Deque<Snapshot> changelogSnapshots,
+      Set<Long> changelogSnapshotIds,
+      Map<String, DeleteFile> activeDVsAtStart,
+      Map<Long, DeleteFileChanges> dvChangesBySnapshot) {
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
+    List<ChangelogScanTask> tasks = Lists.newArrayList();
+    Map<String, ManifestEntry.Status> currentSnapshotFileStatuses =
+        buildCurrentSnapshotFileStatuses(changelogSnapshots, changelogSnapshotIds);
+    Map<String, DeleteFile> activeDVs = Maps.newHashMap(activeDVsAtStart);
+
     for (Snapshot snapshot : changelogSnapshots) {
-      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
-      if (addedDeleteIndex.isEmpty()) {
+      long snapshotId = snapshot.snapshotId();
+      DeleteFileChanges changes = dvChangesBySnapshot.get(snapshotId);
+
+      if (changes.addedDVs().isEmpty()) {
+        applyDVChanges(activeDVs, changes);
         continue;
       }
 
-      // Collect partitions of newly added delete files for pruning (important for the current
-      // snapshot)
-      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-        affectedPartitions.add(df.specId(), df.partition());
-      }
-
-      DeleteFileIndex cumulativeDeleteIndex =
-          buildDeleteIndex(accumulatedDeletes, affectedPartitions);
-
-      // Process data files for this snapshot
-      // Use a local set per snapshot to track processed files
-      Set<String> alreadyProcessedPaths = Sets.newHashSet();
-      processSnapshotForDeletedRowsTasks(
+      planDeletedRowsTasks(
           snapshot,
-          addedDeleteIndex,
-          cumulativeDeleteIndex,
-          fileStatusBySnapshot.get(snapshot.snapshotId()),
-          alreadyProcessedPaths,
-          snapshotOrdinals,
-          affectedPartitions,
+          snapshotOrdinals.get(snapshotId),
+          currentSnapshotFileStatuses,
+          activeDVs,
+          changes.addedDVs(),
           tasks);
-
-      // Accumulate this snapshot's added deletes for subsequent snapshots
-      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-        accumulatedDeletes.add(df);
-      }
+      applyDVChanges(activeDVs, changes);
     }
 
     return CloseableIterable.withNoopClose(tasks);
   }
 
-  /**
-   * Builds a map of file statuses for each snapshot, tracking which files were added or deleted in
-   * each snapshot.
-   */
-  private Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet>
-      buildFileStatusBySnapshot(
-          Deque<Snapshot> changelogSnapshots, Set<Long> changelogSnapshotIds) {
-
-    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot = Maps.newConcurrentMap();
-    java.util.Queue<PartitionSet> localPartitionsQueue =
-        new java.util.concurrent.ConcurrentLinkedQueue<>();
-
-    Tasks.foreach(changelogSnapshots)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .run(
-            snapshot -> {
-              Map<String, ManifestEntry.Status> fileStatuses = Maps.newHashMap();
-              PartitionSet localAffected = PartitionSet.create(table().specs());
-
-              List<ManifestFile> changedDataManifests =
-                  FluentIterable.from(snapshot.dataManifests(table().io()))
-                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
-                      .toList();
-
-              if (!changedDataManifests.isEmpty()) {
-                ManifestGroup changedGroup =
-                    new ManifestGroup(table().io(), changedDataManifests, ImmutableList.of())
-                        .specsById(table().specs())
-                        .caseSensitive(isCaseSensitive())
-                        .select(scanColumns())
-                        .filterData(filter())
-                        .ignoreExisting()
-                        .columnsToKeepStats(columnsToKeepStats());
-
-                try (CloseableIterable<ManifestEntry<DataFile>> entries = changedGroup.entries()) {
-                  for (ManifestEntry<DataFile> entry : entries) {
-                    if (changelogSnapshotIds.contains(entry.snapshotId())) {
-                      fileStatuses.put(entry.file().location(), entry.status());
-                      localAffected.add(entry.file().specId(), entry.file().partition());
-                    }
-                  }
-                } catch (Exception e) {
-                  throw new RuntimeException(
-                      "Failed to collect file statuses for snapshot " + snapshot.snapshotId(), e);
-                }
-              }
-
-              fileStatusBySnapshot.put(snapshot.snapshotId(), fileStatuses);
-              localPartitionsQueue.add(localAffected);
-            });
-
-    PartitionSet globalAffected = PartitionSet.create(table().specs());
-    for (PartitionSet local : localPartitionsQueue) {
-      globalAffected.addAll(local);
-    }
-
-    return Pair.of(fileStatusBySnapshot, globalAffected);
+  private Long beforeFirstSnapshotId(Deque<Snapshot> changelogSnapshots) {
+    Snapshot firstSnapshot = changelogSnapshots.peekFirst();
+    return firstSnapshot != null ? firstSnapshot.parentId() : null;
   }
 
-  private List<ManifestFile> pruneManifestsByAffectedPartitions(
-      List<ManifestFile> manifests, PartitionSet affectedPartitions) {
-    if (affectedPartitions.isEmpty()) {
-      return manifests;
+  private void applyDVChanges(Map<String, DeleteFile> activeDVs, DeleteFileChanges changes) {
+    for (DeleteFile removedDV : changes.removedDVs()) {
+      activeDVs.remove(removedDV.referencedDataFile());
     }
 
-    Expression affectedExpr = buildAffectedPartitionExpression(affectedPartitions);
-    if (affectedExpr == Expressions.alwaysFalse()) {
-      return manifests;
+    for (DeleteFile addedDV : changes.addedDVs()) {
+      activeDVs.put(addedDV.referencedDataFile(), addedDV);
     }
-
-    List<ManifestFile> pruned = Lists.newArrayList();
-    for (ManifestFile manifest : manifests) {
-      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
-      if (spec == null || spec.isUnpartitioned()) {
-        pruned.add(manifest);
-      } else if (manifestOverlapsFilter(manifest, spec, affectedExpr)) {
-        pruned.add(manifest);
-      }
-    }
-    return pruned;
   }
 
-  private Expression buildAffectedPartitionExpression(PartitionSet affectedPartitions) {
-    Expression combined = null;
+  private Map<String, ManifestEntry.Status> buildCurrentSnapshotFileStatuses(
+      Deque<Snapshot> changelogSnapshots, Set<Long> changelogSnapshotIds) {
+    Map<String, ManifestEntry.Status> fileStatuses = Maps.newHashMap();
 
-    for (Pair<Integer, StructLike> pair : affectedPartitions) {
-      int specId = pair.first();
-      StructLike partition = pair.second();
-      PartitionSpec spec = table().specs().get(specId);
-      if (spec == null) {
-        continue;
-      } else if (spec.isUnpartitioned()) {
-        return Expressions.alwaysTrue(); // FALLBACK: Global delete exists, include ALL manifests!
-      }
-
-      Expression specExpr = null;
-      for (int i = 0; i < spec.fields().size(); i++) {
-        org.apache.iceberg.PartitionField field = spec.fields().get(i);
-        Object value = partition.get(i, Object.class);
-        if (value != null) {
-          String columnName = table().schema().findColumnName(field.sourceId());
-          if (columnName != null) {
-            Expression equalExpr = Expressions.equal(columnName, value);
-            specExpr = (specExpr == null) ? equalExpr : Expressions.and(specExpr, equalExpr);
-          }
-        }
-      }
-
-      if (specExpr != null) {
-        combined = (combined == null) ? specExpr : Expressions.or(combined, specExpr);
-      }
-    }
-
-    return combined != null ? combined : Expressions.alwaysFalse();
-  }
-
-  /**
-   * Builds a map of snapshot ID -> all delete files that were added in the scan range up to that
-   * snapshot, PRUNING files that were removed in the middle.
-   */
-  private Map<Long, List<DeleteFile>> buildCumulativeDeletesBySnapshot(
-      Deque<Snapshot> snapshots, Map<Long, DeleteFileIndex> addedDeletesBySnapshot) {
-    Map<Long, List<DeleteFile>> result = Maps.newHashMap();
-    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
-
-    for (Snapshot snapshot : snapshots) {
-      // Save state first, so that this snapshot's tasks can use any deletes active up to this point
-      result.put(snapshot.snapshotId(), Lists.newArrayList(accumulatedDeletes));
-
-      // Check for removed deletes and prune from accumulatedDeletes for FUTURE snapshots
-      List<ManifestFile> changedDeletes =
-          FluentIterable.from(snapshot.deleteManifests(table().io()))
+    for (Snapshot snapshot : changelogSnapshots) {
+      List<ManifestFile> changedDataManifests =
+          FluentIterable.from(snapshot.dataManifests(table().io()))
               .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
               .toList();
 
-      if (!changedDeletes.isEmpty()) {
-        Iterable<DeleteFile> removedDeletes =
-            loadRemovedDeleteFiles(changedDeletes, snapshot.snapshotId());
-        Set<String> removedPaths = Sets.newHashSet();
-        for (DeleteFile rdf : removedDeletes) {
-          removedPaths.add(rdf.location());
-        }
-        accumulatedDeletes.removeIf(df -> removedPaths.contains(df.location()));
-      }
+      ManifestGroup changedGroup =
+          new ManifestGroup(table().io(), changedDataManifests, ImmutableList.of())
+              .specsById(table().specs())
+              .caseSensitive(isCaseSensitive())
+              .select(scanColumns())
+              .filterData(filter())
+              .ignoreExisting()
+              .columnsToKeepStats(columnsToKeepStats());
 
-      // Add new deletes for FUTURE snapshots
-      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
-      if (addedDeleteIndex != null && !addedDeleteIndex.isEmpty()) {
-        for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
-          accumulatedDeletes.add(df);
+      try (CloseableIterable<ManifestEntry<DataFile>> entries = changedGroup.entries()) {
+        for (ManifestEntry<DataFile> entry : entries) {
+          if (changelogSnapshotIds.contains(entry.snapshotId())) {
+            fileStatuses.put(fileStatusKey(snapshot.snapshotId(), entry.file()), entry.status());
+          }
         }
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Failed to read data manifests for snapshot " + snapshot.snapshotId(), e);
       }
     }
 
-    return result;
+    return fileStatuses;
   }
 
-  /**
-   * Builds a delete index from the accumulated list of delete files, pruning by affected
-   * partitions.
-   */
-  private DeleteFileIndex buildDeleteIndex(
-      List<DeleteFile> accumulatedDeletes, PartitionSet affectedPartitions) {
-    if (accumulatedDeletes.isEmpty()) {
-      return DeleteFileIndex.emptyIndex();
-    }
-
-    List<DeleteFile> filteredDeletes = accumulatedDeletes;
-    if (!affectedPartitions.isEmpty()) {
-      filteredDeletes = Lists.newArrayList();
-      for (DeleteFile df : accumulatedDeletes) {
-        PartitionSpec spec = table().specs().get(df.specId());
-        if (spec == null || spec.isUnpartitioned()) {
-          filteredDeletes.add(df); // Always include unpartitioned deletes
-        } else if (affectedPartitions.contains(df.specId(), df.partition())) {
-          filteredDeletes.add(df);
-        }
-      }
-    }
-
-    return DeleteFileIndex.builderFor(filteredDeletes)
-        .specsById(table().specs())
-        .caseSensitive(isCaseSensitive())
-        .build();
+  private String fileStatusKey(long snapshotId, DataFile file) {
+    return snapshotId + "#" + file.location();
   }
 
-  /**
-   * Processes data files for a snapshot to create DeletedRowsScanTask for existing files affected
-   * by new delete files.
-   */
-  private void processSnapshotForDeletedRowsTasks(
+  private void planDeletedRowsTasks(
       Snapshot snapshot,
-      DeleteFileIndex addedDeleteIndex,
-      DeleteFileIndex cumulativeDeleteIndex,
-      Map<String, ManifestEntry.Status> currentSnapshotFiles,
-      Set<String> alreadyProcessedPaths,
-      Map<Long, Integer> snapshotOrdinals,
-      PartitionSet affectedPartitions,
+      int changeOrdinal,
+      Map<String, ManifestEntry.Status> currentSnapshotFileStatuses,
+      Map<String, DeleteFile> activeDVs,
+      List<DeleteFile> addedDVs,
       List<ChangelogScanTask> tasks) {
+    Map<String, DeleteFile> addedDVsByDataFile = Maps.newHashMap();
+    for (DeleteFile addedDV : addedDVs) {
+      addedDVsByDataFile.put(addedDV.referencedDataFile(), addedDV);
+    }
 
-    // Get all data files that exist in this snapshot, pruned by affected partitions
-    List<ManifestFile> allDataManifests = snapshot.dataManifests(table().io());
-    List<ManifestFile> prunedManifests =
-        pruneManifestsByAffectedPartitions(allDataManifests, affectedPartitions);
-
-    ManifestGroup allDataGroup =
-        new ManifestGroup(table().io(), prunedManifests, ImmutableList.of())
+    ManifestGroup manifestGroup =
+        new ManifestGroup(table().io(), snapshot.dataManifests(table().io()), ImmutableList.of())
             .specsById(table().specs())
             .caseSensitive(isCaseSensitive())
             .select(scanColumns())
@@ -594,50 +366,24 @@ class BaseIncrementalChangelogScan
             .columnsToKeepStats(columnsToKeepStats());
 
     if (shouldIgnoreResiduals()) {
-      allDataGroup = allDataGroup.ignoreResiduals();
+      manifestGroup = manifestGroup.ignoreResiduals();
     }
 
     String schemaString = SchemaParser.toJson(schema());
-
-    // Cache per specId - same for all files with same specId
     Map<Integer, String> specStringCache = Maps.newHashMap();
     Map<Integer, ResidualEvaluator> residualCache = Maps.newHashMap();
-    Expression residualFilter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
 
-    try (CloseableIterable<ManifestEntry<DataFile>> entries = allDataGroup.entries()) {
+    try (CloseableIterable<ManifestEntry<DataFile>> entries = manifestGroup.entries()) {
       for (ManifestEntry<DataFile> entry : entries) {
         DataFile dataFile = entry.file();
-        String filePath = dataFile.location();
+        String dataFilePath = dataFile.location().toString();
 
-        // Skip if this file was ADDED or DELETED in this snapshot
-        // (those are handled by CreateDataFileChangeTasks)
-        if (currentSnapshotFiles.containsKey(filePath)) {
+        if (!addedDVsByDataFile.containsKey(dataFilePath)
+            || currentSnapshotFileStatuses.containsKey(
+                fileStatusKey(snapshot.snapshotId(), dataFile))) {
           continue;
         }
 
-        // Skip if we already created a task for this file in this snapshot
-        // Note: alreadyProcessedPaths is local to this snapshot's processing
-        if (alreadyProcessedPaths.contains(filePath)) {
-          continue;
-        }
-
-        // Check if this data file is affected by newly added delete files
-        DeleteFile[] addedDeletes = addedDeleteIndex.forEntry(entry);
-        if (addedDeletes.length == 0) {
-          continue;
-        }
-
-        // This data file was EXISTING but has new delete files applied
-        // Get existing deletes from before this snapshot (cumulative)
-        DeleteFile[] existingDeletes =
-            cumulativeDeleteIndex.isEmpty()
-                ? new DeleteFile[0]
-                : cumulativeDeleteIndex.forEntry(entry);
-
-        // Create a DeletedRowsScanTask
-        int changeOrdinal = snapshotOrdinals.get(snapshot.snapshotId());
-
-        // Use cached values (calculate once per specId)
         int specId = dataFile.specId();
         String specString =
             specStringCache.computeIfAbsent(
@@ -647,25 +393,31 @@ class BaseIncrementalChangelogScan
                 specId,
                 id -> {
                   PartitionSpec spec = table().specs().get(id);
-                  return ResidualEvaluator.of(spec, residualFilter, isCaseSensitive());
+                  return ResidualEvaluator.of(
+                      spec,
+                      shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter(),
+                      isCaseSensitive());
                 });
+
+        DeleteFile addedDV = addedDVsByDataFile.get(dataFilePath);
+        DeleteFile existingDV = activeDVs.get(dataFilePath);
+        DeleteFile[] existingDeletes =
+            existingDV != null ? new DeleteFile[] {existingDV} : NO_DELETES;
 
         tasks.add(
             new BaseDeletedRowsScanTask(
                 changeOrdinal,
                 snapshot.snapshotId(),
                 dataFile.copy(shouldKeepStats()),
-                addedDeletes,
+                new DeleteFile[] {addedDV},
                 existingDeletes,
                 schemaString,
                 specString,
                 residuals));
-
-        // Mark this file as processed for this snapshot
-        alreadyProcessedPaths.add(filePath);
       }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to plan deleted rows tasks", e);
+    } catch (IOException e) {
+      throw new UncheckedIOException(
+          "Failed to read data manifests for snapshot " + snapshot.snapshotId(), e);
     }
   }
 
@@ -674,232 +426,18 @@ class BaseIncrementalChangelogScan
     return columns != null && !columns.isEmpty();
   }
 
-  /**
-   * Loads delete files from manifests by parsing each manifest.
-   *
-   * @param manifests the delete manifests to load
-   * @return list of delete files
-   */
-  private Iterable<DeleteFile> loadDeleteFiles(
-      List<ManifestFile> manifests, Long targetSnapshotId) {
-    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
-
-    Tasks.foreach(manifests)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .run(
-            manifest -> {
-              List<DeleteFile> deleteFiles =
-                  loadDeleteFilesFromManifest(manifest, targetSnapshotId);
-              allDeleteFiles.addAll(deleteFiles);
-            });
-
-    return allDeleteFiles;
-  }
-
-  private Iterable<DeleteFile> loadRemovedDeleteFiles(
-      List<ManifestFile> manifests, Long targetSnapshotId) {
-    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
-
-    Tasks.foreach(manifests)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(planExecutor())
-        .run(
-            manifest -> {
-              List<DeleteFile> deleteFiles =
-                  loadRemovedDeleteFilesFromManifest(manifest, targetSnapshotId);
-              allDeleteFiles.addAll(deleteFiles);
-            });
-
-    return allDeleteFiles;
-  }
-
-  private List<DeleteFile> loadRemovedDeleteFilesFromManifest(
-      ManifestFile manifest, Long targetSnapshotId) {
-    List<DeleteFile> deleteFiles = Lists.newArrayList();
-
-    try (ManifestReader<DeleteFile> reader =
-        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
-      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
-        if (entry.status() == ManifestEntry.Status.DELETED
-            && entry.snapshotId().equals(targetSnapshotId)) {
-          DeleteFile file = entry.file();
-
-          if (!partitionMatchesFilter(file)) {
-            continue;
-          }
-
-          Set<Integer> columns =
-              file.content() == FileContent.POSITION_DELETES
-                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
-                  : Set.copyOf(file.equalityFieldIds());
-          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
-    }
-
-    return deleteFiles;
-  }
-
-  /**
-   * Prunes delete manifests based on partition filter to avoid processing irrelevant manifests.
-   * This significantly improves performance when only a subset of partitions are relevant to the
-   * scan.
-   *
-   * @param manifests all delete manifests to consider
-   * @return list of manifests that might contain relevant delete files
-   */
-  private List<ManifestFile> pruneManifestsByPartition(List<ManifestFile> manifests) {
-    Expression currentFilter = filter();
-
-    // If there's no filter, return all manifests
-    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
-      return manifests;
-    }
-
-    List<ManifestFile> prunedManifests = Lists.newArrayList();
-
-    for (ManifestFile manifest : manifests) {
-      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
-      if (spec == null || spec.isUnpartitioned()) {
-        // Include unpartitioned manifests
-        prunedManifests.add(manifest);
-      } else if (manifestOverlapsFilter(manifest, spec, currentFilter)) {
-        // Check if manifest partition range overlaps with filter
-        prunedManifests.add(manifest);
-      }
-    }
-
-    return prunedManifests;
-  }
-
-  /**
-   * Checks if a manifest's partition range overlaps with the given filter.
-   *
-   * @param manifest the manifest to check
-   * @param spec the partition spec for the manifest
-   * @param filter the scan filter
-   * @return true if the manifest might contain matching partitions, false otherwise
-   */
-  private boolean manifestOverlapsFilter(
-      ManifestFile manifest, PartitionSpec spec, Expression filter) {
-    try {
-      // Use inclusive projection to transform row filter to partition filter
-      Expression partitionFilter = Projections.inclusive(spec, isCaseSensitive()).project(filter);
-
-      // Create evaluator for the partition filter
-      ManifestEvaluator evaluator =
-          ManifestEvaluator.forPartitionFilter(partitionFilter, spec, isCaseSensitive());
-
-      // Check if manifest could contain matching partitions
-      return evaluator.eval(manifest);
-    } catch (Exception e) {
-      // If evaluation fails, be conservative and include the manifest
-      return true;
-    }
-  }
-
-  /**
-   * Checks if a delete file's partition overlaps with the current scan filter. This enables
-   * partition pruning to reduce memory footprint and planning overhead by skipping delete files
-   * that cannot possibly match any rows in the scan.
-   *
-   * @param file the delete file to check
-   * @return true if the delete file's partition might contain matching rows, false otherwise
-   */
-  private boolean partitionMatchesFilter(DeleteFile file) {
-    // If there's no filter, all partitions match
-    Expression currentFilter = filter();
-    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
-      return true;
-    }
-
-    // Get the partition spec for this delete file
-    PartitionSpec spec = table().specs().get(file.specId());
-    if (spec == null || spec.isUnpartitioned()) {
-      // If spec not found or table is unpartitioned, be conservative and include the file
-      return true;
-    }
-
-    try {
-      // Project the row filter to partition space using inclusive projection
-      // This transforms expressions on source columns to expressions on partition columns
-      Expression partitionFilter =
-          Projections.inclusive(spec, isCaseSensitive()).project(currentFilter);
-
-      // Evaluate the projected filter against the delete file's partition
-      Evaluator evaluator = new Evaluator(spec.partitionType(), partitionFilter, isCaseSensitive());
-      return evaluator.eval(file.partition());
-    } catch (Exception e) {
-      // If evaluation fails, be conservative and include the file
-      return true;
-    }
-  }
-
-  /**
-   * Loads delete files from a single manifest, parsing the manifest entries.
-   *
-   * @param manifest the delete manifest to load
-   * @return list of delete files from this manifest
-   */
-  private List<DeleteFile> loadDeleteFilesFromManifest(
-      ManifestFile manifest, Long targetSnapshotId) {
-    List<DeleteFile> deleteFiles = Lists.newArrayList();
-
-    try (ManifestReader<DeleteFile> reader =
-        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
-      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
-        if (entry.status() != ManifestEntry.Status.DELETED
-            && (targetSnapshotId == null || entry.snapshotId().equals(targetSnapshotId))) {
-          // Only include live delete files, copy with minimal stats to save memory
-          DeleteFile file = entry.file();
-
-          // Apply partition pruning - skip delete files that cannot match the scan filter
-          if (!partitionMatchesFilter(file)) {
-            continue;
-          }
-
-          Set<Integer> columns =
-              file.content() == FileContent.POSITION_DELETES
-                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
-                  : Set.copyOf(file.equalityFieldIds());
-          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
-        }
-      }
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
-    }
-
-    return deleteFiles;
-  }
-
   private static class CreateDataFileChangeTasks implements CreateTasksFunction<ChangelogScanTask> {
-    private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
-
     private final Map<Long, Integer> snapshotOrdinals;
-    private final Supplier<DeleteFileIndex> existingDeleteIndexSupplier;
-    private final Map<Long, DeleteFileIndex> addedDeletesBySnapshot;
-    private final Map<Long, List<DeleteFile>> cumulativeDeletesMap;
-    private final Map<Integer, PartitionSpec> specsById;
-    private final boolean caseSensitive;
+    private final Map<Long, DeleteFileChanges> dvChangesBySnapshot;
+    private final Map<Long, Map<String, DeleteFile>> activeDVsBySnapshot;
 
     CreateDataFileChangeTasks(
         Deque<Snapshot> snapshots,
-        Supplier<DeleteFileIndex> existingDeleteIndexSupplier,
-        Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
-        Map<Long, List<DeleteFile>> cumulativeDeletesMap,
-        Map<Integer, PartitionSpec> specsById,
-        boolean caseSensitive) {
+        Map<Long, DeleteFileChanges> dvChangesBySnapshot,
+        Map<Long, Map<String, DeleteFile>> activeDVsBySnapshot) {
       this.snapshotOrdinals = computeSnapshotOrdinals(snapshots);
-      this.existingDeleteIndexSupplier = existingDeleteIndexSupplier;
-      this.addedDeletesBySnapshot = addedDeletesBySnapshot;
-      this.cumulativeDeletesMap = cumulativeDeletesMap;
-      this.specsById = specsById;
-      this.caseSensitive = caseSensitive;
+      this.dvChangesBySnapshot = dvChangesBySnapshot;
+      this.activeDVsBySnapshot = activeDVsBySnapshot;
     }
 
     @Override
@@ -915,26 +453,21 @@ class BaseIncrementalChangelogScan
 
             switch (entry.status()) {
               case ADDED:
-                // For ADDED data files, attach delete files added in this snapshot
-                DeleteFile[] addedFileDeletes = getDeletesForAddedFile(entry, commitSnapshotId);
                 return new BaseAddedRowsScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    addedFileDeletes,
+                    addedDVsForDataFile(commitSnapshotId, entry.file()),
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
 
               case DELETED:
-                // For DELETED data files, attach ALL deletes that were present up to deletion
-                // This includes existing deletes AND deletes added in the scan range
-                DeleteFile[] deletedFileDeletes = getDeletesForDeletedFile(entry, commitSnapshotId);
                 return new BaseDeletedDataFileScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    deletedFileDeletes,
+                    activeDVsForDataFile(commitSnapshotId, entry.file()),
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
@@ -945,51 +478,47 @@ class BaseIncrementalChangelogScan
           });
     }
 
-    /**
-     * Gets delete files that apply to an ADDED data file. Only includes deletes added in the same
-     * snapshot as the file.
-     */
-    private DeleteFile[] getDeletesForAddedFile(
-        ManifestEntry<DataFile> entry, long commitSnapshotId) {
-      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(commitSnapshotId);
-      return addedDeleteIndex == null || addedDeleteIndex.isEmpty()
-          ? NO_DELETES
-          : addedDeleteIndex.forEntry(entry);
-    }
-
-    /**
-     * Gets all delete files that were applied to a DELETED data file up to the point it was
-     * deleted. This includes existing deletes and all deletes added in the scan range up to (but
-     * not including) the deletion snapshot.
-     */
-    private DeleteFile[] getDeletesForDeletedFile(
-        ManifestEntry<DataFile> entry, long deletionSnapshotId) {
-
-      List<DeleteFile> allDeletes = Lists.newArrayList();
-
-      // Build existing delete index lazily when first DELETED entry is encountered
-      DeleteFileIndex existingDeleteIndex = existingDeleteIndexSupplier.get();
-      DeleteFile[] existingDeletes =
-          existingDeleteIndex.isEmpty() ? NO_DELETES : existingDeleteIndex.forEntry(entry);
-      for (DeleteFile df : existingDeletes) {
-        allDeletes.add(df);
+    private DeleteFile[] addedDVsForDataFile(long snapshotId, DataFile dataFile) {
+      DeleteFileChanges changes = dvChangesBySnapshot.get(snapshotId);
+      if (changes == null || changes.addedDVs().isEmpty()) {
+        return NO_DELETES;
       }
 
-      // Add all deletes from snapshots in the scan range BEFORE the deletion
-      List<DeleteFile> cumulativeDeletes = cumulativeDeletesMap.get(deletionSnapshotId);
-      if (cumulativeDeletes != null && !cumulativeDeletes.isEmpty()) {
-        DeleteFileIndex tempIndex =
-            DeleteFileIndex.builderFor(cumulativeDeletes)
-                .specsById(specsById)
-                .caseSensitive(caseSensitive)
-                .build();
-        DeleteFile[] applicable = tempIndex.forEntry(entry);
-        for (DeleteFile deleteFile : applicable) {
-          allDeletes.add(deleteFile);
+      for (DeleteFile dv : changes.addedDVs()) {
+        if (dv.referencedDataFile().contentEquals(dataFile.location())) {
+          return new DeleteFile[] {dv};
         }
       }
 
-      return allDeletes.isEmpty() ? NO_DELETES : allDeletes.toArray(new DeleteFile[0]);
+      return NO_DELETES;
+    }
+
+    private DeleteFile[] activeDVsForDataFile(long snapshotId, DataFile dataFile) {
+      Map<String, DeleteFile> activeDVs = activeDVsBySnapshot.get(snapshotId);
+      if (activeDVs == null) {
+        return NO_DELETES;
+      }
+
+      DeleteFile dv = activeDVs.get(dataFile.location().toString());
+      return dv != null ? new DeleteFile[] {dv} : NO_DELETES;
+    }
+  }
+
+  private static class DeleteFileChanges {
+    private final List<DeleteFile> addedDVs;
+    private final List<DeleteFile> removedDVs;
+
+    DeleteFileChanges(List<DeleteFile> addedDVs, List<DeleteFile> removedDVs) {
+      this.addedDVs = addedDVs;
+      this.removedDVs = removedDVs;
+    }
+
+    List<DeleteFile> addedDVs() {
+      return addedDVs;
+    }
+
+    List<DeleteFile> removedDVs() {
+      return removedDVs;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -20,23 +20,46 @@ package org.apache.iceberg;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Deque;
+import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestGroup.CreateTasksFunction;
 import org.apache.iceberg.ManifestGroup.TaskContext;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ManifestEvaluator;
+import org.apache.iceberg.expressions.Projections;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.FluentIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.TableScanUtil;
+import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class BaseIncrementalChangelogScan
     extends BaseIncrementalScan<
         IncrementalChangelogScan, ChangelogScanTask, ScanTaskGroup<ChangelogScanTask>>
     implements IncrementalChangelogScan {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseIncrementalChangelogScan.class);
 
   BaseIncrementalChangelogScan(Table table) {
     this(table, table.schema(), TableScanContext.empty());
@@ -51,6 +74,12 @@ class BaseIncrementalChangelogScan
       Table newTable, Schema newSchema, TableScanContext newContext) {
     return new BaseIncrementalChangelogScan(newTable, newSchema, newContext);
   }
+
+  // Private fields to track build call count and cache (accessed via package-private methods for
+  // testing)
+  private int existingDeleteIndexBuildCallCount = 0;
+  // Cache for the built index (null if not built yet)
+  private DeleteFileIndex cachedExistingDeleteIndex = null;
 
   @Override
   protected CloseableIterable<ChangelogScanTask> doPlanFiles(
@@ -71,6 +100,20 @@ class BaseIncrementalChangelogScan
             .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
             .toSet();
 
+    // Build per-snapshot delete file indexes for added deletes
+    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = buildAddedDeleteIndexes(changelogSnapshots);
+
+    // Check if existing delete index is needed for equality deletes
+    boolean hasEqualityDeletes =
+        addedDeletesBySnapshot.values().stream()
+            .anyMatch(index -> !index.isEmpty() && index.hasEqualityDeletes());
+
+    // Build existing index early if needed for equality deletes, otherwise use lazy initialization
+    DeleteFileIndex existingDeleteIndex =
+        hasEqualityDeletes
+            ? buildExistingDeleteIndexTracked(fromSnapshotIdExclusive)
+            : DeleteFileIndex.emptyIndex();
+
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
             .specsById(table().specs())
@@ -89,7 +132,41 @@ class BaseIncrementalChangelogScan
       manifestGroup = manifestGroup.planWith(planExecutor());
     }
 
-    return manifestGroup.plan(new CreateDataFileChangeTasks(changelogSnapshots));
+    // Create a supplier that reuses already-built index or builds lazily when first DELETED entry
+    // is encountered
+    Supplier<DeleteFileIndex> existingDeleteIndexSupplier =
+        () -> {
+          if (cachedExistingDeleteIndex != null) {
+            return cachedExistingDeleteIndex;
+          }
+          return buildExistingDeleteIndexTracked(fromSnapshotIdExclusive);
+        };
+
+    // Plan data file tasks (ADDED and DELETED)
+    Map<Long, List<DeleteFile>> cumulativeDeletesMap =
+        buildCumulativeDeletesBySnapshot(changelogSnapshots, addedDeletesBySnapshot);
+
+    CloseableIterable<ChangelogScanTask> dataFileTasks =
+        manifestGroup.plan(
+            new CreateDataFileChangeTasks(
+                changelogSnapshots,
+                existingDeleteIndexSupplier,
+                addedDeletesBySnapshot,
+                cumulativeDeletesMap,
+                table().specs(),
+                isCaseSensitive()));
+
+    // Find EXISTING data files affected by newly added delete files and create tasks for them
+    CloseableIterable<ChangelogScanTask> deletedRowsTasks =
+        planDeletedRowsTasks(
+            changelogSnapshots, existingDeleteIndex, addedDeletesBySnapshot, changelogSnapshotIds);
+
+    // Merge tasks from both iterables in order by changeOrdinal
+    Comparator<ChangelogScanTask> byOrdinal =
+        Comparator.comparing(ChangelogScanTask::changeOrdinal)
+            .thenComparing(ChangelogScanTask::commitSnapshotId);
+
+    return new SortedMerge<>(byOrdinal, ImmutableList.of(dataFileTasks, deletedRowsTasks));
   }
 
   @Override
@@ -105,11 +182,6 @@ class BaseIncrementalChangelogScan
 
     for (Snapshot snapshot : SnapshotUtil.ancestorsBetween(table(), toIdIncl, fromIdExcl)) {
       if (!snapshot.operation().equals(DataOperations.REPLACE)) {
-        if (!snapshot.deleteManifests(table().io()).isEmpty()) {
-          throw new UnsupportedOperationException(
-              "Delete files are currently not supported in changelog scans");
-        }
-
         changelogSnapshots.addFirst(snapshot);
       }
     }
@@ -133,13 +205,701 @@ class BaseIncrementalChangelogScan
     return snapshotOrdinals;
   }
 
+  /**
+   * Builds a delete file index for existing deletes that were present before the start snapshot.
+   * These deletes should be applied to data files but should not generate DELETE changelog rows.
+   * Uses manifest pruning and caching to optimize performance.
+   */
+  private DeleteFileIndex buildExistingDeleteIndex(Long fromSnapshotIdExclusive) {
+    if (fromSnapshotIdExclusive == null) {
+      return DeleteFileIndex.emptyIndex();
+    }
+    Snapshot fromSnapshot = table().snapshot(fromSnapshotIdExclusive);
+    Preconditions.checkState(
+        fromSnapshot != null, "Cannot find starting snapshot: %s", fromSnapshotIdExclusive);
+
+    List<ManifestFile> existingDeleteManifests = fromSnapshot.deleteManifests(table().io());
+    if (existingDeleteManifests.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    // Prune manifests based on partition filter to avoid processing irrelevant manifests
+    List<ManifestFile> prunedManifests = pruneManifestsByPartition(existingDeleteManifests);
+    if (prunedManifests.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    // Load delete files from manifests
+    Iterable<DeleteFile> deleteFiles = loadDeleteFiles(prunedManifests, null);
+
+    return DeleteFileIndex.builderFor(deleteFiles)
+        .specsById(table().specs())
+        .caseSensitive(isCaseSensitive())
+        .build();
+  }
+
+  /**
+   * Wrapper method that tracks build calls and caches the result for reuse. This ensures we only
+   * build the index once even if called from multiple places.
+   */
+  private DeleteFileIndex buildExistingDeleteIndexTracked(Long fromSnapshotIdExclusive) {
+    if (cachedExistingDeleteIndex != null) {
+      return cachedExistingDeleteIndex;
+    }
+    existingDeleteIndexBuildCallCount++;
+    cachedExistingDeleteIndex = buildExistingDeleteIndex(fromSnapshotIdExclusive);
+    return cachedExistingDeleteIndex;
+  }
+
+  // Visible for testing
+  int getExistingDeleteIndexBuildCallCount() {
+    return existingDeleteIndexBuildCallCount;
+  }
+
+  // Visible for testing
+  boolean wasExistingDeleteIndexBuilt() {
+    return existingDeleteIndexBuildCallCount > 0;
+  }
+
+  /**
+   * Builds per-snapshot delete file indexes for newly added delete files in each changelog
+   * snapshot. These deletes should generate DELETE changelog rows. Uses caching to avoid re-parsing
+   * manifests.
+   */
+  private Map<Long, DeleteFileIndex> buildAddedDeleteIndexes(Deque<Snapshot> changelogSnapshots) {
+    Map<Long, DeleteFileIndex> addedDeletesBySnapshot = Maps.newConcurrentMap();
+    Tasks.foreach(changelogSnapshots)
+        .retry(3)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .onFailure(
+            (snapshot, exc) ->
+                LOG.warn(
+                    "Failed to build delete index for snapshot {}", snapshot.snapshotId(), exc))
+        .run(
+            snapshot -> {
+              List<ManifestFile> snapshotDeleteManifests = snapshot.deleteManifests(table().io());
+              if (snapshotDeleteManifests.isEmpty()) {
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
+                return;
+              }
+
+              // Filter to only include delete files added in this snapshot
+              List<ManifestFile> addedDeleteManifests =
+                  snapshotDeleteManifests.stream()
+                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+                      .collect(Collectors.toUnmodifiableList());
+
+              if (addedDeleteManifests.isEmpty()) {
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), DeleteFileIndex.emptyIndex());
+              } else {
+                // Load delete files from manifests
+                Iterable<DeleteFile> deleteFiles =
+                    loadDeleteFiles(addedDeleteManifests, snapshot.snapshotId());
+
+                DeleteFileIndex index =
+                    DeleteFileIndex.builderFor(deleteFiles)
+                        .specsById(table().specs())
+                        .caseSensitive(isCaseSensitive())
+                        .build();
+                addedDeletesBySnapshot.put(snapshot.snapshotId(), index);
+              }
+            });
+    return addedDeletesBySnapshot;
+  }
+
+  /**
+   * Plans tasks for EXISTING data files that are affected by newly added delete files. These files
+   * were not added or deleted in the changelog snapshot range, but have new delete files applied to
+   * them.
+   */
+  private CloseableIterable<ChangelogScanTask> planDeletedRowsTasks(
+      Deque<Snapshot> changelogSnapshots,
+      DeleteFileIndex existingDeleteIndex,
+      Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+      Set<Long> changelogSnapshotIds) {
+
+    Map<Long, Integer> snapshotOrdinals = computeSnapshotOrdinals(changelogSnapshots);
+    List<ChangelogScanTask> tasks = Lists.newArrayList();
+
+    // Build a map of file statuses and collect affected partitions for each snapshot
+    Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet> fileStatusAndPartitions =
+        buildFileStatusBySnapshot(changelogSnapshots, changelogSnapshotIds);
+    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot =
+        fileStatusAndPartitions.first();
+    PartitionSet affectedPartitions = fileStatusAndPartitions.second();
+
+    // Accumulate actual DeleteFile entries chronologically
+    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+
+    // Start with deletes from before the changelog range
+    if (!existingDeleteIndex.isEmpty()) {
+      for (DeleteFile df : existingDeleteIndex.referencedDeleteFiles()) {
+        accumulatedDeletes.add(df);
+      }
+    }
+
+    for (Snapshot snapshot : changelogSnapshots) {
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+      if (addedDeleteIndex.isEmpty()) {
+        continue;
+      }
+
+      // Collect partitions of newly added delete files for pruning (important for the current
+      // snapshot)
+      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+        affectedPartitions.add(df.specId(), df.partition());
+      }
+
+      DeleteFileIndex cumulativeDeleteIndex =
+          buildDeleteIndex(accumulatedDeletes, affectedPartitions);
+
+      // Process data files for this snapshot
+      // Use a local set per snapshot to track processed files
+      Set<String> alreadyProcessedPaths = Sets.newHashSet();
+      processSnapshotForDeletedRowsTasks(
+          snapshot,
+          addedDeleteIndex,
+          cumulativeDeleteIndex,
+          fileStatusBySnapshot.get(snapshot.snapshotId()),
+          alreadyProcessedPaths,
+          snapshotOrdinals,
+          affectedPartitions,
+          tasks);
+
+      // Accumulate this snapshot's added deletes for subsequent snapshots
+      for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+        accumulatedDeletes.add(df);
+      }
+    }
+
+    return CloseableIterable.withNoopClose(tasks);
+  }
+
+  /**
+   * Builds a map of file statuses for each snapshot, tracking which files were added or deleted in
+   * each snapshot.
+   */
+  private Pair<Map<Long, Map<String, ManifestEntry.Status>>, PartitionSet>
+      buildFileStatusBySnapshot(
+          Deque<Snapshot> changelogSnapshots, Set<Long> changelogSnapshotIds) {
+
+    Map<Long, Map<String, ManifestEntry.Status>> fileStatusBySnapshot = Maps.newConcurrentMap();
+    java.util.Queue<PartitionSet> localPartitionsQueue =
+        new java.util.concurrent.ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(changelogSnapshots)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            snapshot -> {
+              Map<String, ManifestEntry.Status> fileStatuses = Maps.newHashMap();
+              PartitionSet localAffected = PartitionSet.create(table().specs());
+
+              List<ManifestFile> changedDataManifests =
+                  FluentIterable.from(snapshot.dataManifests(table().io()))
+                      .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+                      .toList();
+
+              if (!changedDataManifests.isEmpty()) {
+                ManifestGroup changedGroup =
+                    new ManifestGroup(table().io(), changedDataManifests, ImmutableList.of())
+                        .specsById(table().specs())
+                        .caseSensitive(isCaseSensitive())
+                        .select(scanColumns())
+                        .filterData(filter())
+                        .ignoreExisting()
+                        .columnsToKeepStats(columnsToKeepStats());
+
+                try (CloseableIterable<ManifestEntry<DataFile>> entries = changedGroup.entries()) {
+                  for (ManifestEntry<DataFile> entry : entries) {
+                    if (changelogSnapshotIds.contains(entry.snapshotId())) {
+                      fileStatuses.put(entry.file().location(), entry.status());
+                      localAffected.add(entry.file().specId(), entry.file().partition());
+                    }
+                  }
+                } catch (Exception e) {
+                  throw new RuntimeException(
+                      "Failed to collect file statuses for snapshot " + snapshot.snapshotId(), e);
+                }
+              }
+
+              fileStatusBySnapshot.put(snapshot.snapshotId(), fileStatuses);
+              localPartitionsQueue.add(localAffected);
+            });
+
+    PartitionSet globalAffected = PartitionSet.create(table().specs());
+    for (PartitionSet local : localPartitionsQueue) {
+      globalAffected.addAll(local);
+    }
+
+    return Pair.of(fileStatusBySnapshot, globalAffected);
+  }
+
+  private List<ManifestFile> pruneManifestsByAffectedPartitions(
+      List<ManifestFile> manifests, PartitionSet affectedPartitions) {
+    if (affectedPartitions.isEmpty()) {
+      return manifests;
+    }
+
+    Expression affectedExpr = buildAffectedPartitionExpression(affectedPartitions);
+    if (affectedExpr == Expressions.alwaysFalse()) {
+      return manifests;
+    }
+
+    List<ManifestFile> pruned = Lists.newArrayList();
+    for (ManifestFile manifest : manifests) {
+      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
+      if (spec == null || spec.isUnpartitioned()) {
+        pruned.add(manifest);
+      } else if (manifestOverlapsFilter(manifest, spec, affectedExpr)) {
+        pruned.add(manifest);
+      }
+    }
+    return pruned;
+  }
+
+  private Expression buildAffectedPartitionExpression(PartitionSet affectedPartitions) {
+    Expression combined = null;
+
+    for (Pair<Integer, StructLike> pair : affectedPartitions) {
+      int specId = pair.first();
+      StructLike partition = pair.second();
+      PartitionSpec spec = table().specs().get(specId);
+      if (spec == null) {
+        continue;
+      } else if (spec.isUnpartitioned()) {
+        return Expressions.alwaysTrue(); // FALLBACK: Global delete exists, include ALL manifests!
+      }
+
+      Expression specExpr = null;
+      for (int i = 0; i < spec.fields().size(); i++) {
+        org.apache.iceberg.PartitionField field = spec.fields().get(i);
+        Object value = partition.get(i, Object.class);
+        if (value != null) {
+          String columnName = table().schema().findColumnName(field.sourceId());
+          if (columnName != null) {
+            Expression equalExpr = Expressions.equal(columnName, value);
+            specExpr = (specExpr == null) ? equalExpr : Expressions.and(specExpr, equalExpr);
+          }
+        }
+      }
+
+      if (specExpr != null) {
+        combined = (combined == null) ? specExpr : Expressions.or(combined, specExpr);
+      }
+    }
+
+    return combined != null ? combined : Expressions.alwaysFalse();
+  }
+
+  /**
+   * Builds a map of snapshot ID -> all delete files that were added in the scan range up to that
+   * snapshot, PRUNING files that were removed in the middle.
+   */
+  private Map<Long, List<DeleteFile>> buildCumulativeDeletesBySnapshot(
+      Deque<Snapshot> snapshots, Map<Long, DeleteFileIndex> addedDeletesBySnapshot) {
+    Map<Long, List<DeleteFile>> result = Maps.newHashMap();
+    List<DeleteFile> accumulatedDeletes = Lists.newArrayList();
+
+    for (Snapshot snapshot : snapshots) {
+      // Save state first, so that this snapshot's tasks can use any deletes active up to this point
+      result.put(snapshot.snapshotId(), Lists.newArrayList(accumulatedDeletes));
+
+      // Check for removed deletes and prune from accumulatedDeletes for FUTURE snapshots
+      List<ManifestFile> changedDeletes =
+          FluentIterable.from(snapshot.deleteManifests(table().io()))
+              .filter(manifest -> manifest.snapshotId().equals(snapshot.snapshotId()))
+              .toList();
+
+      if (!changedDeletes.isEmpty()) {
+        Iterable<DeleteFile> removedDeletes =
+            loadRemovedDeleteFiles(changedDeletes, snapshot.snapshotId());
+        Set<String> removedPaths = Sets.newHashSet();
+        for (DeleteFile rdf : removedDeletes) {
+          removedPaths.add(rdf.location());
+        }
+        accumulatedDeletes.removeIf(df -> removedPaths.contains(df.location()));
+      }
+
+      // Add new deletes for FUTURE snapshots
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(snapshot.snapshotId());
+      if (addedDeleteIndex != null && !addedDeleteIndex.isEmpty()) {
+        for (DeleteFile df : addedDeleteIndex.referencedDeleteFiles()) {
+          accumulatedDeletes.add(df);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Builds a delete index from the accumulated list of delete files, pruning by affected
+   * partitions.
+   */
+  private DeleteFileIndex buildDeleteIndex(
+      List<DeleteFile> accumulatedDeletes, PartitionSet affectedPartitions) {
+    if (accumulatedDeletes.isEmpty()) {
+      return DeleteFileIndex.emptyIndex();
+    }
+
+    List<DeleteFile> filteredDeletes = accumulatedDeletes;
+    if (!affectedPartitions.isEmpty()) {
+      filteredDeletes = Lists.newArrayList();
+      for (DeleteFile df : accumulatedDeletes) {
+        PartitionSpec spec = table().specs().get(df.specId());
+        if (spec == null || spec.isUnpartitioned()) {
+          filteredDeletes.add(df); // Always include unpartitioned deletes
+        } else if (affectedPartitions.contains(df.specId(), df.partition())) {
+          filteredDeletes.add(df);
+        }
+      }
+    }
+
+    return DeleteFileIndex.builderFor(filteredDeletes)
+        .specsById(table().specs())
+        .caseSensitive(isCaseSensitive())
+        .build();
+  }
+
+  /**
+   * Processes data files for a snapshot to create DeletedRowsScanTask for existing files affected
+   * by new delete files.
+   */
+  private void processSnapshotForDeletedRowsTasks(
+      Snapshot snapshot,
+      DeleteFileIndex addedDeleteIndex,
+      DeleteFileIndex cumulativeDeleteIndex,
+      Map<String, ManifestEntry.Status> currentSnapshotFiles,
+      Set<String> alreadyProcessedPaths,
+      Map<Long, Integer> snapshotOrdinals,
+      PartitionSet affectedPartitions,
+      List<ChangelogScanTask> tasks) {
+
+    // Get all data files that exist in this snapshot, pruned by affected partitions
+    List<ManifestFile> allDataManifests = snapshot.dataManifests(table().io());
+    List<ManifestFile> prunedManifests =
+        pruneManifestsByAffectedPartitions(allDataManifests, affectedPartitions);
+
+    ManifestGroup allDataGroup =
+        new ManifestGroup(table().io(), prunedManifests, ImmutableList.of())
+            .specsById(table().specs())
+            .caseSensitive(isCaseSensitive())
+            .select(scanColumns())
+            .filterData(filter())
+            .ignoreDeleted()
+            .columnsToKeepStats(columnsToKeepStats());
+
+    if (shouldIgnoreResiduals()) {
+      allDataGroup = allDataGroup.ignoreResiduals();
+    }
+
+    String schemaString = SchemaParser.toJson(schema());
+
+    // Cache per specId - same for all files with same specId
+    Map<Integer, String> specStringCache = Maps.newHashMap();
+    Map<Integer, ResidualEvaluator> residualCache = Maps.newHashMap();
+    Expression residualFilter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
+
+    try (CloseableIterable<ManifestEntry<DataFile>> entries = allDataGroup.entries()) {
+      for (ManifestEntry<DataFile> entry : entries) {
+        DataFile dataFile = entry.file();
+        String filePath = dataFile.location();
+
+        // Skip if this file was ADDED or DELETED in this snapshot
+        // (those are handled by CreateDataFileChangeTasks)
+        if (currentSnapshotFiles.containsKey(filePath)) {
+          continue;
+        }
+
+        // Skip if we already created a task for this file in this snapshot
+        // Note: alreadyProcessedPaths is local to this snapshot's processing
+        if (alreadyProcessedPaths.contains(filePath)) {
+          continue;
+        }
+
+        // Check if this data file is affected by newly added delete files
+        DeleteFile[] addedDeletes = addedDeleteIndex.forEntry(entry);
+        if (addedDeletes.length == 0) {
+          continue;
+        }
+
+        // This data file was EXISTING but has new delete files applied
+        // Get existing deletes from before this snapshot (cumulative)
+        DeleteFile[] existingDeletes =
+            cumulativeDeleteIndex.isEmpty()
+                ? new DeleteFile[0]
+                : cumulativeDeleteIndex.forEntry(entry);
+
+        // Create a DeletedRowsScanTask
+        int changeOrdinal = snapshotOrdinals.get(snapshot.snapshotId());
+
+        // Use cached values (calculate once per specId)
+        int specId = dataFile.specId();
+        String specString =
+            specStringCache.computeIfAbsent(
+                specId, id -> PartitionSpecParser.toJson(table().specs().get(id)));
+        ResidualEvaluator residuals =
+            residualCache.computeIfAbsent(
+                specId,
+                id -> {
+                  PartitionSpec spec = table().specs().get(id);
+                  return ResidualEvaluator.of(spec, residualFilter, isCaseSensitive());
+                });
+
+        tasks.add(
+            new BaseDeletedRowsScanTask(
+                changeOrdinal,
+                snapshot.snapshotId(),
+                dataFile.copy(shouldKeepStats()),
+                addedDeletes,
+                existingDeletes,
+                schemaString,
+                specString,
+                residuals));
+
+        // Mark this file as processed for this snapshot
+        alreadyProcessedPaths.add(filePath);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to plan deleted rows tasks", e);
+    }
+  }
+
+  private boolean shouldKeepStats() {
+    Set<Integer> columns = columnsToKeepStats();
+    return columns != null && !columns.isEmpty();
+  }
+
+  /**
+   * Loads delete files from manifests by parsing each manifest.
+   *
+   * @param manifests the delete manifests to load
+   * @return list of delete files
+   */
+  private Iterable<DeleteFile> loadDeleteFiles(
+      List<ManifestFile> manifests, Long targetSnapshotId) {
+    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(manifests)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            manifest -> {
+              List<DeleteFile> deleteFiles =
+                  loadDeleteFilesFromManifest(manifest, targetSnapshotId);
+              allDeleteFiles.addAll(deleteFiles);
+            });
+
+    return allDeleteFiles;
+  }
+
+  private Iterable<DeleteFile> loadRemovedDeleteFiles(
+      List<ManifestFile> manifests, Long targetSnapshotId) {
+    Queue<DeleteFile> allDeleteFiles = new ConcurrentLinkedQueue<>();
+
+    Tasks.foreach(manifests)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(planExecutor())
+        .run(
+            manifest -> {
+              List<DeleteFile> deleteFiles =
+                  loadRemovedDeleteFilesFromManifest(manifest, targetSnapshotId);
+              allDeleteFiles.addAll(deleteFiles);
+            });
+
+    return allDeleteFiles;
+  }
+
+  private List<DeleteFile> loadRemovedDeleteFilesFromManifest(
+      ManifestFile manifest, Long targetSnapshotId) {
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        if (entry.status() == ManifestEntry.Status.DELETED
+            && entry.snapshotId().equals(targetSnapshotId)) {
+          DeleteFile file = entry.file();
+
+          if (!partitionMatchesFilter(file)) {
+            continue;
+          }
+
+          Set<Integer> columns =
+              file.content() == FileContent.POSITION_DELETES
+                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
+                  : Set.copyOf(file.equalityFieldIds());
+          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
+    }
+
+    return deleteFiles;
+  }
+
+  /**
+   * Prunes delete manifests based on partition filter to avoid processing irrelevant manifests.
+   * This significantly improves performance when only a subset of partitions are relevant to the
+   * scan.
+   *
+   * @param manifests all delete manifests to consider
+   * @return list of manifests that might contain relevant delete files
+   */
+  private List<ManifestFile> pruneManifestsByPartition(List<ManifestFile> manifests) {
+    Expression currentFilter = filter();
+
+    // If there's no filter, return all manifests
+    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
+      return manifests;
+    }
+
+    List<ManifestFile> prunedManifests = Lists.newArrayList();
+
+    for (ManifestFile manifest : manifests) {
+      PartitionSpec spec = table().specs().get(manifest.partitionSpecId());
+      if (spec == null || spec.isUnpartitioned()) {
+        // Include unpartitioned manifests
+        prunedManifests.add(manifest);
+      } else if (manifestOverlapsFilter(manifest, spec, currentFilter)) {
+        // Check if manifest partition range overlaps with filter
+        prunedManifests.add(manifest);
+      }
+    }
+
+    return prunedManifests;
+  }
+
+  /**
+   * Checks if a manifest's partition range overlaps with the given filter.
+   *
+   * @param manifest the manifest to check
+   * @param spec the partition spec for the manifest
+   * @param filter the scan filter
+   * @return true if the manifest might contain matching partitions, false otherwise
+   */
+  private boolean manifestOverlapsFilter(
+      ManifestFile manifest, PartitionSpec spec, Expression filter) {
+    try {
+      // Use inclusive projection to transform row filter to partition filter
+      Expression partitionFilter = Projections.inclusive(spec, isCaseSensitive()).project(filter);
+
+      // Create evaluator for the partition filter
+      ManifestEvaluator evaluator =
+          ManifestEvaluator.forPartitionFilter(partitionFilter, spec, isCaseSensitive());
+
+      // Check if manifest could contain matching partitions
+      return evaluator.eval(manifest);
+    } catch (Exception e) {
+      // If evaluation fails, be conservative and include the manifest
+      return true;
+    }
+  }
+
+  /**
+   * Checks if a delete file's partition overlaps with the current scan filter. This enables
+   * partition pruning to reduce memory footprint and planning overhead by skipping delete files
+   * that cannot possibly match any rows in the scan.
+   *
+   * @param file the delete file to check
+   * @return true if the delete file's partition might contain matching rows, false otherwise
+   */
+  private boolean partitionMatchesFilter(DeleteFile file) {
+    // If there's no filter, all partitions match
+    Expression currentFilter = filter();
+    if (currentFilter == null || currentFilter.equals(Expressions.alwaysTrue())) {
+      return true;
+    }
+
+    // Get the partition spec for this delete file
+    PartitionSpec spec = table().specs().get(file.specId());
+    if (spec == null || spec.isUnpartitioned()) {
+      // If spec not found or table is unpartitioned, be conservative and include the file
+      return true;
+    }
+
+    try {
+      // Project the row filter to partition space using inclusive projection
+      // This transforms expressions on source columns to expressions on partition columns
+      Expression partitionFilter =
+          Projections.inclusive(spec, isCaseSensitive()).project(currentFilter);
+
+      // Evaluate the projected filter against the delete file's partition
+      Evaluator evaluator = new Evaluator(spec.partitionType(), partitionFilter, isCaseSensitive());
+      return evaluator.eval(file.partition());
+    } catch (Exception e) {
+      // If evaluation fails, be conservative and include the file
+      return true;
+    }
+  }
+
+  /**
+   * Loads delete files from a single manifest, parsing the manifest entries.
+   *
+   * @param manifest the delete manifest to load
+   * @return list of delete files from this manifest
+   */
+  private List<DeleteFile> loadDeleteFilesFromManifest(
+      ManifestFile manifest, Long targetSnapshotId) {
+    List<DeleteFile> deleteFiles = Lists.newArrayList();
+
+    try (ManifestReader<DeleteFile> reader =
+        ManifestFiles.readDeleteManifest(manifest, table().io(), table().specs())) {
+      for (ManifestEntry<DeleteFile> entry : reader.entries()) {
+        if (entry.status() != ManifestEntry.Status.DELETED
+            && (targetSnapshotId == null || entry.snapshotId().equals(targetSnapshotId))) {
+          // Only include live delete files, copy with minimal stats to save memory
+          DeleteFile file = entry.file();
+
+          // Apply partition pruning - skip delete files that cannot match the scan filter
+          if (!partitionMatchesFilter(file)) {
+            continue;
+          }
+
+          Set<Integer> columns =
+              file.content() == FileContent.POSITION_DELETES
+                  ? Set.of(MetadataColumns.DELETE_FILE_PATH.fieldId())
+                  : Set.copyOf(file.equalityFieldIds());
+          deleteFiles.add(ContentFileUtil.copy(file, true, columns));
+        }
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to read delete manifest: " + manifest.path(), e);
+    }
+
+    return deleteFiles;
+  }
+
   private static class CreateDataFileChangeTasks implements CreateTasksFunction<ChangelogScanTask> {
     private static final DeleteFile[] NO_DELETES = new DeleteFile[0];
 
     private final Map<Long, Integer> snapshotOrdinals;
+    private final Supplier<DeleteFileIndex> existingDeleteIndexSupplier;
+    private final Map<Long, DeleteFileIndex> addedDeletesBySnapshot;
+    private final Map<Long, List<DeleteFile>> cumulativeDeletesMap;
+    private final Map<Integer, PartitionSpec> specsById;
+    private final boolean caseSensitive;
 
-    CreateDataFileChangeTasks(Deque<Snapshot> snapshots) {
+    CreateDataFileChangeTasks(
+        Deque<Snapshot> snapshots,
+        Supplier<DeleteFileIndex> existingDeleteIndexSupplier,
+        Map<Long, DeleteFileIndex> addedDeletesBySnapshot,
+        Map<Long, List<DeleteFile>> cumulativeDeletesMap,
+        Map<Integer, PartitionSpec> specsById,
+        boolean caseSensitive) {
       this.snapshotOrdinals = computeSnapshotOrdinals(snapshots);
+      this.existingDeleteIndexSupplier = existingDeleteIndexSupplier;
+      this.addedDeletesBySnapshot = addedDeletesBySnapshot;
+      this.cumulativeDeletesMap = cumulativeDeletesMap;
+      this.specsById = specsById;
+      this.caseSensitive = caseSensitive;
     }
 
     @Override
@@ -155,21 +915,26 @@ class BaseIncrementalChangelogScan
 
             switch (entry.status()) {
               case ADDED:
+                // For ADDED data files, attach delete files added in this snapshot
+                DeleteFile[] addedFileDeletes = getDeletesForAddedFile(entry, commitSnapshotId);
                 return new BaseAddedRowsScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    NO_DELETES,
+                    addedFileDeletes,
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
 
               case DELETED:
+                // For DELETED data files, attach ALL deletes that were present up to deletion
+                // This includes existing deletes AND deletes added in the scan range
+                DeleteFile[] deletedFileDeletes = getDeletesForDeletedFile(entry, commitSnapshotId);
                 return new BaseDeletedDataFileScanTask(
                     changeOrdinal,
                     commitSnapshotId,
                     dataFile,
-                    NO_DELETES,
+                    deletedFileDeletes,
                     context.schemaAsString(),
                     context.specAsString(),
                     context.residuals());
@@ -178,6 +943,53 @@ class BaseIncrementalChangelogScan
                 throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
             }
           });
+    }
+
+    /**
+     * Gets delete files that apply to an ADDED data file. Only includes deletes added in the same
+     * snapshot as the file.
+     */
+    private DeleteFile[] getDeletesForAddedFile(
+        ManifestEntry<DataFile> entry, long commitSnapshotId) {
+      DeleteFileIndex addedDeleteIndex = addedDeletesBySnapshot.get(commitSnapshotId);
+      return addedDeleteIndex == null || addedDeleteIndex.isEmpty()
+          ? NO_DELETES
+          : addedDeleteIndex.forEntry(entry);
+    }
+
+    /**
+     * Gets all delete files that were applied to a DELETED data file up to the point it was
+     * deleted. This includes existing deletes and all deletes added in the scan range up to (but
+     * not including) the deletion snapshot.
+     */
+    private DeleteFile[] getDeletesForDeletedFile(
+        ManifestEntry<DataFile> entry, long deletionSnapshotId) {
+
+      List<DeleteFile> allDeletes = Lists.newArrayList();
+
+      // Build existing delete index lazily when first DELETED entry is encountered
+      DeleteFileIndex existingDeleteIndex = existingDeleteIndexSupplier.get();
+      DeleteFile[] existingDeletes =
+          existingDeleteIndex.isEmpty() ? NO_DELETES : existingDeleteIndex.forEntry(entry);
+      for (DeleteFile df : existingDeletes) {
+        allDeletes.add(df);
+      }
+
+      // Add all deletes from snapshots in the scan range BEFORE the deletion
+      List<DeleteFile> cumulativeDeletes = cumulativeDeletesMap.get(deletionSnapshotId);
+      if (cumulativeDeletes != null && !cumulativeDeletes.isEmpty()) {
+        DeleteFileIndex tempIndex =
+            DeleteFileIndex.builderFor(cumulativeDeletes)
+                .specsById(specsById)
+                .caseSensitive(caseSensitive)
+                .build();
+        DeleteFile[] applicable = tempIndex.forEntry(entry);
+        for (DeleteFile deleteFile : applicable) {
+          allDeletes.add(deleteFile);
+        }
+      }
+
+      return allDeletes.isEmpty() ? NO_DELETES : allDeletes.toArray(new DeleteFile[0]);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -69,6 +69,7 @@ import org.apache.iceberg.util.Tasks;
  */
 class DeleteFileIndex {
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
+  private static final DeleteFileIndex EMPTY = new DeleteFileIndex(null, null, null, null, null);
 
   private final EqualityDeletes globalDeletes;
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
@@ -361,6 +362,10 @@ class DeleteFileIndex {
 
   static Builder builderFor(Iterable<DeleteFile> deleteFiles) {
     return new Builder(deleteFiles);
+  }
+
+  static DeleteFileIndex emptyIndex() {
+    return EMPTY;
   }
 
   static class Builder {

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -69,7 +69,6 @@ import org.apache.iceberg.util.Tasks;
  */
 class DeleteFileIndex {
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
-  private static final DeleteFileIndex EMPTY = new DeleteFileIndex(null, null, null, null, null);
 
   private final EqualityDeletes globalDeletes;
   private final PartitionMap<EqualityDeletes> eqDeletesByPartition;
@@ -362,10 +361,6 @@ class DeleteFileIndex {
 
   static Builder builderFor(Iterable<DeleteFile> deleteFiles) {
     return new Builder(deleteFiles);
-  }
-
-  static DeleteFileIndex emptyIndex() {
-    return EMPTY;
   }
 
   static class Builder {

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -247,15 +248,15 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
-  public void testPositionDeletesOnExistingFile() {
-    assumeThat(formatVersion).isEqualTo(2);
+  public void testDeletionVectorOnExistingFile() {
+    assumeThat(formatVersion).isEqualTo(3);
 
-    // Add initial data files
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
     Snapshot snap1 = table.currentSnapshot();
 
-    // Add position deletes for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    table.newRowDelta().addDeletes(FILE_A_DV).commit();
+
     Snapshot snap2 = table.currentSnapshot();
 
     IncrementalChangelogScan scan =
@@ -263,685 +264,86 @@ public class TestBaseIncrementalChangelogScan
 
     List<ChangelogScanTask> tasks = plan(scan);
 
-    // Should have one DeletedRowsScanTask for FILE_A
     assertThat(tasks).as("Must have 1 task").hasSize(1);
 
     DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
     assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
     assertThat(task.addedDeletes())
-        .as("Must have added deletes")
-        .hasSize(1)
+        .as("Must have the added DV")
         .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
+        .containsExactly(FILE_A_DV.location());
     assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
   }
 
   @TestTemplate
-  public void testEqualityDeletesOnExistingFile() {
-    assumeThat(formatVersion).isEqualTo(2);
+  public void testAddedFileWithDeletionVectorInSameSnapshot() {
+    assumeThat(formatVersion).isEqualTo(3);
 
-    // Add initial data files
-    table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
+    table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DV).commit();
+
     Snapshot snap1 = table.currentSnapshot();
 
-    // Add equality deletes for FILE_A2
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
     IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+        newScan().fromSnapshotInclusive(snap1.snapshotId()).toSnapshot(snap1.snapshotId());
 
     List<ChangelogScanTask> tasks = plan(scan);
 
-    // Should have one DeletedRowsScanTask for FILE_A2
-    assertThat(tasks).as("Must have 1 task").hasSize(1);
-
-    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
-    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task.addedDeletes())
-        .as("Must have added deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
-  }
-
-  @TestTemplate
-  public void testAddedFileWithExistingDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Add FILE_A with deletes
-    table.newFastAppend().appendFile(FILE_A).commit();
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Add FILE_B in the changelog range
-    table.newFastAppend().appendFile(FILE_B).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have one AddedRowsScanTask for FILE_B (no deletes apply to FILE_B)
     assertThat(tasks).as("Must have 1 task").hasSize(1);
 
     AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
-    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
-    assertThat(task.deletes()).as("Must have no deletes").isEmpty();
-  }
-
-  @TestTemplate
-  public void testDeletedFileWithExistingDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-
-    // Add deletes for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Delete FILE_A in the changelog range
-    table.newDelete().deleteFile(FILE_A).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have one DeletedDataFileScanTask for FILE_A with existing deletes
-    assertThat(tasks).as("Must have 1 task").hasSize(1);
-
-    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
-    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap1.snapshotId());
     assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task.existingDeletes())
-        .as("Must have existing deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testMultipleSnapshotsWithDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A and FILE_B
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add deletes for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add FILE_C
-    table.newFastAppend().appendFile(FILE_C).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    // Snapshot 4: Add deletes for FILE_B
-    DeleteFile fileBDeletes =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofPositionDeletes()
-            .withPath("/path/to/data-b-deletes.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=1")
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(fileBDeletes).commit();
-    Snapshot snap4 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have:
-    // 1. DeletedRowsScanTask for FILE_A (snap2)
-    // 2. AddedRowsScanTask for FILE_C (snap3)
-    // 3. DeletedRowsScanTask for FILE_B (snap4)
-    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
-
-    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_C.location());
-
-    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
-    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
-    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
-    assertThat(task3.addedDeletes()).as("Must have added deletes").hasSize(1);
-  }
-
-  @TestTemplate
-  public void testInsertDeleteReinsert() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Insert FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add equality delete for FILE_A
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Re-insert FILE_A (same file, new snapshot)
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have:
-    // 1. DeletedRowsScanTask for FILE_A affected by delete (snap2)
-    // 2. AddedRowsScanTask for FILE_A re-insert (snap3)
-    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
-
-    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    // The re-inserted file is a fresh insert, so the deletes from snap2 were already
-    // accounted for in the DeletedRowsScanTask above
-    assertThat(task2.deletes()).as("Re-insert should not carry previous deletes").isEmpty();
-  }
-
-  @TestTemplate
-  public void testInsertAndDeleteInSameCommit() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: baseline
-    table.newFastAppend().appendFile(FILE_B).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add FILE_A and delete it in the same commit (using row delta)
-    table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should emit an AddedRowsScanTask with deletes attached
-    // The net result depends on whether all rows are deleted
-    assertThat(tasks).as("Must have 1 task").hasSize(1);
-
-    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
-    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
-    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    // The delete should be attached to the added file task
     assertThat(task.deletes())
-        .as("Must have deletes")
-        .hasSize(1)
+        .as("Must have the added DV")
         .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
+        .containsExactly(FILE_A_DV.location());
   }
 
   @TestTemplate
-  public void testOverlappingEqualityAndPositionDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
+  public void testDeletedFileWithExistingDeletionVector() {
+    assumeThat(formatVersion).isEqualTo(3);
 
-    // Snapshot 1: Add FILE_A
     table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
 
-    // Snapshot 2: Add position deletes for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    table.newRowDelta().addDeletes(FILE_A_DV).commit();
+
     Snapshot snap2 = table.currentSnapshot();
 
-    // Snapshot 3: Add equality deletes that also affect FILE_A
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have 2 DeletedRowsScanTask for FILE_A (one per snapshot with deletes)
-    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task1.addedDeletes())
-        .as("Must have 1 added delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
-
-    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task2.addedDeletes())
-        .as("Must have 1 added delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    // The position delete from snap2 should be an existing delete for snap3
-    assertThat(task2.existingDeletes())
-        .as("Must be 1 position delete from previous snapshot")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testEqualityDeleteOverlapsEqualityDelete() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A2 (has equality delete support)
-    table.newFastAppend().appendFile(FILE_A2).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add equality delete on field 'id'
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add equality delete on different field 'data' that matches the same logical rows
-    // This tests behavior when two equality deletes on different columns target overlapping
-    // rows
-    DeleteFile eqDeleteOnData =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-data.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0")
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(eqDeleteOnData).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have 2 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
-    // This documents current behavior - whether duplicate DELETE rows are emitted or deduplicated
-    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task1.addedDeletes())
-        .as("Must have first equality delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
-
-    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task2.addedDeletes())
-        .as("Must have second equality delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(eqDeleteOnData.location());
-    // First equality delete should be an existing delete for the second task
-    assertThat(task2.existingDeletes())
-        .as("Must have first equality delete as existing")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testDeletedFileWithBothDeleteTypes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add position deletes for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add equality deletes for FILE_A (potentially overlapping)
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    // Snapshot 4: Delete FILE_A entirely
     table.newDelete().deleteFile(FILE_A).commit();
-    Snapshot snap4 = table.currentSnapshot();
 
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have:
-    // 1. DeletedRowsScanTask for FILE_A with position deletes (snap2)
-    // 2. DeletedRowsScanTask for FILE_A with equality deletes (snap3)
-    // 3. DeletedDataFileScanTask for FILE_A deletion (snap4) with both types of existing deletes
-    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task1.addedDeletes())
-        .as("Must have position deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
-
-    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task2.addedDeletes())
-        .as("Must have equality deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    // Position delete from snap2 should be an existing delete for snap3
-    assertThat(task2.existingDeletes())
-        .as("Must have position delete as existing")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-
-    DeletedDataFileScanTask task3 = (DeletedDataFileScanTask) tasks.get(2);
-    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
-    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    // When file is deleted, all existing deletes should be included to omit previously deleted rows
-    assertThat(task3.existingDeletes())
-        .as("Must have both position and equality deletes as existing")
-        .hasSize(2)
-        .extracting(DeleteFile::location)
-        .containsExactlyInAnyOrder(FILE_A_DELETES.location(), FILE_A2_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testMultipleEqualityDeletesSameFile() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A2
-    table.newFastAppend().appendFile(FILE_A2).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add equality delete #1 on field 'id'
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add equality delete #2 on field 'id' (different values, no overlap)
-    DeleteFile eqDelete2 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-2.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0")
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(eqDelete2).commit();
     Snapshot snap3 = table.currentSnapshot();
 
-    // Snapshot 4: Add equality delete #3 on field 'data' (potentially overlaps with delete #1 or
-    // #2)
-    DeleteFile eqDelete3 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-3.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0")
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(eqDelete3).commit();
-    Snapshot snap4 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have 3 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
-    // This documents cumulative equality delete tracking across multiple snapshots
-    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
-
-    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task1.addedDeletes())
-        .as("Must have first equality delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
-
-    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task2.addedDeletes())
-        .as("Must have second equality delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(eqDelete2.location());
-    // First equality delete should be an existing delete for the second task
-    assertThat(task2.existingDeletes())
-        .as("Must have first equality delete as existing")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-
-    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
-    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
-    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
-    assertThat(task3.addedDeletes())
-        .as("Must have third equality delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(eqDelete3.location());
-    // Both previous equality deletes should be existing deletes for the third task
-    assertThat(task3.existingDeletes())
-        .as("Must have both previous equality deletes as existing")
-        .hasSize(2)
-        .extracting(DeleteFile::location)
-        .containsExactlyInAnyOrder(FILE_A2_DELETES.location(), eqDelete2.location());
-  }
-
-  @TestTemplate
-  public void testExistingAndNewDeletesBothApplied() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A with position deletes
-    table.newFastAppend().appendFile(FILE_A).commit();
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add FILE_B
-    table.newFastAppend().appendFile(FILE_B).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add equality deletes affecting FILE_A
-    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have:
-    // 1. AddedRowsScanTask for FILE_B (snap2)
-    // 2. DeletedRowsScanTask for FILE_A with new equality delete (snap3)
-    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
-
-    AddedRowsScanTask task1 = (AddedRowsScanTask) tasks.get(0);
-    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
-    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
-
-    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
-    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
-    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    assertThat(task2.addedDeletes())
-        .as("Must have newly added delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A2_DELETES.location());
-    assertThat(task2.existingDeletes())
-        .as("Must have existing delete")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testOverwriteSnapshotWithExistingDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A and FILE_B with deletes on FILE_A
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Overwrite - replace FILE_A with FILE_A2, keep FILE_B
-    table.newOverwrite().addFile(FILE_A2).deleteFile(FILE_A).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    // Should not throw NPE and should handle the overwrite correctly
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // The overwrite creates ADDED and DELETED tasks
-    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
-
-    AddedRowsScanTask addedTask = (AddedRowsScanTask) tasks.get(0);
-    assertThat(addedTask.file().location())
-        .as("Added file must match")
-        .isEqualTo(FILE_A2.location());
-
-    DeletedDataFileScanTask deletedTask = (DeletedDataFileScanTask) tasks.get(1);
-    assertThat(deletedTask.file().location())
-        .as("Deleted file must match")
-        .isEqualTo(FILE_A.location());
-    // FILE_A had existing deletes which should be included
-    assertThat(deletedTask.existingDeletes())
-        .as("Must have existing deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-  }
-
-  @TestTemplate
-  public void testDeletedFileWithPreScanRangeDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-
-    // Snapshot 2: Add deletes for FILE_A (before scan range)
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Delete FILE_A entirely (within scan range)
-    table.newDelete().deleteFile(FILE_A).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    // Scan from snap2 (exclusive) to snap3
-    // This means the delete of FILE_A happens within the range,
-    // but the delete file (FILE_A_DELETES) was added before the range
     IncrementalChangelogScan scan =
         newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
 
     List<ChangelogScanTask> tasks = plan(scan);
 
-    // Should have one DeletedDataFileScanTask for FILE_A
     assertThat(tasks).as("Must have 1 task").hasSize(1);
 
     DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
     assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
     assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-
-    // The key assertion: existingDeletes should include FILE_A_DELETES
-    // so consumers know to omit those previously deleted rows
     assertThat(task.existingDeletes())
-        .as("Must include pre-existing deletes to omit previously deleted rows")
-        .hasSize(1)
+        .as("Must have the existing DV")
         .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
+        .containsExactly(FILE_A_DV.location());
   }
 
   @TestTemplate
-  public void testLargeDeleteSetWithPruning() {
-    assumeThat(formatVersion).isEqualTo(2);
+  public void testDeleteFilesAreNotSupported() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
 
-    // Snapshot 1: Add FILE_A in partition 0
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
 
-    // Snapshot 2: Add large equality delete set, but only affecting partition 0
-    // Create multiple equality delete files for different partitions
-    DeleteFile eqDelete1 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-1.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=0")
-            .withRecordCount(100)
-            .build();
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
 
-    DeleteFile eqDelete2 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-2.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=1")
-            .withRecordCount(100)
-            .build();
-
-    DeleteFile eqDelete3 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes(1)
-            .withPath("/path/to/eq-delete-3.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath("data_bucket=2")
-            .withRecordCount(100)
-            .build();
-
-    table.newRowDelta().addDeletes(eqDelete1).addDeletes(eqDelete2).addDeletes(eqDelete3).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have 1 DeletedRowsScanTask for FILE_A
-    // Only eqDelete1 should be included (partition 0), not eqDelete2 or eqDelete3
-    assertThat(tasks).as("Must have 1 task").hasSize(1);
-
-    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
-    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-    // Should only have 1 delete file (the one in partition 0)
-    // The DeleteFileIndex should prune out the other partition's delete files
-    assertThat(task.addedDeletes())
-        .as("Must have only 1 delete (partition pruning should eliminate others)")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(eqDelete1.location());
+    assertThatThrownBy(() -> plan(newScan()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Only deletion vectors in v3 tables are supported in changelog scans");
   }
 
   // plans tasks and reorders them to have deterministic order
@@ -956,45 +358,6 @@ public class TestBaseIncrementalChangelogScan
     }
   }
 
-  @TestTemplate
-  public void testDeleteFilePartitionPruning() throws IOException {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A (partition 0)
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add delete files for FILE_A (partition 0) and FILE_C (partition 2)
-    // FILE_C is not present as a data file, only its delete file
-    table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_C2_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Scan without filter
-    // Partition pruning will automatically exclude FILE_C2_DELETES because:
-    // 1. There's no data file in partition 2 (FILE_C doesn't exist)
-    // 2. The delete file's partition doesn't overlap with any existing data files
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Should have a DeletedRowsScanTask for FILE_A only
-    assertThat(tasks).as("Must have 1 task").hasSize(1);
-
-    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
-
-    // Verify that only FILE_A_DELETES is included (partition 0)
-    // FILE_C2_DELETES should have been pruned because:
-    // - Its partition (data_bucket=2) doesn't contain any data files
-    // - The partition pruning optimization skips it during accumulation
-    assertThat(task.addedDeletes())
-        .as("Must have added deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-  }
-
   private Comparator<? super ChangelogScanTask> taskComparator() {
     return (t1, t2) ->
         ComparisonChain.start()
@@ -1006,363 +369,5 @@ public class TestBaseIncrementalChangelogScan
 
   private String path(ChangelogScanTask task) {
     return ((ContentScanTask<?>) task).file().location().toString();
-  }
-
-  @TestTemplate
-  public void testLazyExistingDeleteIndexAppendOnly() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Scenario 1: Append-only with position deletes (no equality deletes, no DELETED files)
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add position deletes for FILE_A
-    // This creates a DeletedRowsScanTask for EXISTING file FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan1 =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks1 = plan(scan1);
-
-    // Verify no errors and correct results
-    assertThat(tasks1).isNotEmpty();
-
-    // Verify existingDeleteIndex was NOT built (position deletes don't require it)
-    BaseIncrementalChangelogScan baseScan1 = (BaseIncrementalChangelogScan) scan1;
-    assertThat(baseScan1.getExistingDeleteIndexBuildCallCount())
-        .as(
-            "Should not call buildExistingDeleteIndex for position deletes without equality deletes/DELETED files")
-        .isEqualTo(0);
-    assertThat(baseScan1.wasExistingDeleteIndexBuilt())
-        .as(
-            "Should not build existingDeleteIndex for position deletes without equality deletes/DELETED files")
-        .isFalse();
-
-    // Scenario 2: Pure append-only (no deletes at all, no DELETED files)
-    // Snapshot 3: Add FILE_B (pure append, no deletes)
-    table.newFastAppend().appendFile(FILE_B).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan2 =
-        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks2 = plan(scan2);
-
-    // Verify correct results
-    assertThat(tasks2).hasSize(1);
-    AddedRowsScanTask task = (AddedRowsScanTask) tasks2.get(0);
-    assertThat(task.file().location()).isEqualTo(FILE_B.location());
-
-    // Verify existingDeleteIndex was NOT built (pure append, no deletes, no DELETED files)
-    BaseIncrementalChangelogScan baseScan2 = (BaseIncrementalChangelogScan) scan2;
-    assertThat(baseScan2.getExistingDeleteIndexBuildCallCount())
-        .as("Should not call buildExistingDeleteIndex for pure append-only workload")
-        .isEqualTo(0);
-    assertThat(baseScan2.wasExistingDeleteIndexBuilt())
-        .as("Should not build existingDeleteIndex for pure append-only workload")
-        .isFalse();
-  }
-
-  @TestTemplate
-  public void testLazyExistingDeleteIndexWithEqualityDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
-    DeleteFile eqDeletes =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes()
-            .withPath("/path/to/eq-deletes.parquet")
-            .withFileSizeInBytes(10)
-            .withPartition(FILE_A.partition())
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(eqDeletes).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Verify correct results
-    assertThat(tasks).isNotEmpty();
-    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
-    assertThat(task.file().location()).isEqualTo(FILE_A.location());
-
-    // Verify existingDeleteIndex was built EARLY (for equality deletes, not lazily)
-    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
-        .as("Should call buildExistingDeleteIndex exactly once for equality deletes")
-        .isEqualTo(1);
-    assertThat(baseScan.wasExistingDeleteIndexBuilt())
-        .as("Should build existingDeleteIndex early when equality deletes exist")
-        .isTrue();
-  }
-
-  @TestTemplate
-  public void testLazyExistingDeleteIndexWithDeletedFiles() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-
-    // Snapshot 2: Add deletes for FILE_A (before scan range)
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Delete FILE_A entirely (within scan range, no equality deletes)
-    table.newDelete().deleteFile(FILE_A).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Verify correct results
-    assertThat(tasks).hasSize(1);
-    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
-    assertThat(task.file().location()).isEqualTo(FILE_A.location());
-    assertThat(task.existingDeletes())
-        .as("Must include pre-existing deletes")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(FILE_A_DELETES.location());
-
-    // Verify existingDeleteIndex was built LAZILY (on-demand for DELETED file)
-    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
-        .as("Should call buildExistingDeleteIndex exactly once (lazily) for DELETED file")
-        .isEqualTo(1);
-    assertThat(baseScan.wasExistingDeleteIndexBuilt())
-        .as("Should build existingDeleteIndex lazily when DELETED file is encountered")
-        .isTrue();
-  }
-
-  @TestTemplate
-  public void testLazyExistingDeleteIndexWithBothEqualityDeletesAndDeletedFiles() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A and FILE_B
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
-    DeleteFile eqDeletes =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofEqualityDeletes()
-            .withPath("/path/to/eq-deletes.parquet")
-            .withFileSizeInBytes(10)
-            .withPartition(FILE_A.partition())
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(eqDeletes).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Delete FILE_B (different file) - this will trigger Supplier.get()
-    table.newDelete().deleteFile(FILE_B).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Verify correct results
-    assertThat(tasks).isNotEmpty();
-
-    // This proves that the cached index was reused when DELETED file was encountered
-    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
-        .as(
-            "Should call buildExistingDeleteIndex exactly once (early), then reuse cached index for DELETED file")
-        .isEqualTo(1);
-    assertThat(baseScan.wasExistingDeleteIndexBuilt())
-        .as(
-            "Should build existingDeleteIndex early when equality deletes exist, even with DELETED files")
-        .isTrue();
-
-    // ensure DELETED file task has correct deletes
-    DeletedDataFileScanTask deletedTask =
-        tasks.stream()
-            .filter(t -> t instanceof DeletedDataFileScanTask)
-            .map(t -> (DeletedDataFileScanTask) t)
-            .findFirst()
-            .orElse(null);
-    if (deletedTask != null) {
-      assertThat(deletedTask.file().location()).isEqualTo(FILE_B.location());
-    }
-  }
-
-  @TestTemplate
-  public void testLazyExistingDeleteIndexNoExistingDeletes() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Snapshot 1: Add FILE_A (before scan range)
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Delete FILE_A (within scan range, no existing deletes, no equality deletes)
-    table.newDelete().deleteFile(FILE_A).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Verify correct results
-    assertThat(tasks).hasSize(1);
-    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
-    assertThat(task.file().location()).isEqualTo(FILE_A.location());
-    assertThat(task.existingDeletes()).isEmpty();
-
-    // Verify existingDeleteIndex was built (lazily for DELETED file, even though no existing
-    // deletes)
-    // Note: It will be built but will be empty
-    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
-    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
-        .as("Should call buildExistingDeleteIndex exactly once (lazily) even if result is empty")
-        .isEqualTo(1);
-    assertThat(baseScan.wasExistingDeleteIndexBuilt())
-        .as(
-            "Should build existingDeleteIndex when DELETED file is encountered, even with no existing deletes")
-        .isTrue();
-  }
-
-  @TestTemplate
-  public void testMixedDeleteManifestEntries() {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    table
-        .updateProperties()
-        .set(MANIFEST_MIN_MERGE_COUNT, "1")
-        .set(MANIFEST_MERGE_ENABLED, "true")
-        .commit();
-
-    // Snapshot 1: Add FILE_A
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snap1 = table.currentSnapshot();
-
-    // Snapshot 2: Add Delete 1 for FILE_A
-    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
-    Snapshot snap2 = table.currentSnapshot();
-
-    // Snapshot 3: Add Delete 2 for FILE_A
-    DeleteFile fileADeletes2 =
-        FileMetadata.deleteFileBuilder(SPEC)
-            .ofPositionDeletes()
-            .withPath("/path/to/data-a-deletes-2.parquet")
-            .withFileSizeInBytes(10)
-            .withPartition(FILE_A.partition())
-            .withRecordCount(1)
-            .build();
-    table.newRowDelta().addDeletes(fileADeletes2).commit();
-    Snapshot snap3 = table.currentSnapshot();
-
-    // We scan from snap2 to snap3 (meaning we only care about snap3's changes).
-    IncrementalChangelogScan scan =
-        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    assertThat(tasks).isNotEmpty();
-
-    // Find the task for snap3
-    DeletedRowsScanTask snap3Task =
-        tasks.stream()
-            .filter(
-                t -> t instanceof DeletedRowsScanTask && t.commitSnapshotId() == snap3.snapshotId())
-            .map(t -> (DeletedRowsScanTask) t)
-            .findFirst()
-            .orElse(null);
-
-    assertThat(snap3Task).isNotNull();
-    assertThat(snap3Task.addedDeletes())
-        .as("Must only contain the new delete from snap3")
-        .hasSize(1)
-        .extracting(DeleteFile::location)
-        .containsExactly(fileADeletes2.location());
-  }
-
-  @TestTemplate
-  public void testUnpartitionedEqualityDeletePruning() throws Exception {
-    assumeThat(formatVersion).isEqualTo(2);
-
-    // Create a new table specifically for this test, starting unpartitioned (Spec ID 0)
-    String tableName =
-        "test_unpartitioned_pruning_" + java.util.UUID.randomUUID().toString().replace("-", "");
-    TestTables.TestTable localTable =
-        TestTables.create(
-            tableDir, tableName, SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
-
-    // Snapshot 1: Add fileA (unpartitioned, Spec ID 0)
-    DataFile fileA =
-        DataFiles.builder(PartitionSpec.unpartitioned())
-            .withPath(localTable.location() + "/data-unpartitioned-a.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
-    localTable.newFastAppend().appendFile(fileA).commit();
-    Snapshot snap1 = localTable.currentSnapshot();
-
-    // Evolve spec to bucketed (Spec ID 1)
-    localTable
-        .updateSpec()
-        .addField(org.apache.iceberg.expressions.Expressions.bucket("data", 16))
-        .commit();
-    PartitionSpec bucketedSpec = localTable.spec();
-
-    // Snapshot 2: Add fileB (bucketed, Spec ID 1)
-    String bucketFieldName = bucketedSpec.fields().get(0).name();
-    DataFile fileB =
-        DataFiles.builder(bucketedSpec)
-            .withPath(localTable.location() + "/data-bucketed-b.parquet")
-            .withFileSizeInBytes(10)
-            .withPartitionPath(bucketFieldName + "=1")
-            .withRecordCount(1)
-            .build();
-    localTable.newFastAppend().appendFile(fileB).commit();
-    Snapshot snap2 = localTable.currentSnapshot();
-
-    // Snapshot 3: Create an unpartitioned equality delete (Spec ID 0)
-    int idFieldId = localTable.schema().findField("id").fieldId();
-    DeleteFile globalDelete =
-        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
-            .ofEqualityDeletes(idFieldId)
-            .withPath(localTable.location() + "/global-delete.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
-
-    localTable.newRowDelta().addDeletes(globalDelete).commit();
-    Snapshot snap3 = localTable.currentSnapshot();
-
-    // Scan from snap1 exclusive to snap3 using localTable
-    IncrementalChangelogScan scan =
-        localTable
-            .newIncrementalChangelogScan()
-            .fromSnapshotExclusive(snap1.snapshotId())
-            .toSnapshot(snap3.snapshotId());
-
-    List<ChangelogScanTask> tasks = plan(scan);
-
-    // Expecting 3 tasks:
-    // 1 AddedRowsScanTask for fileB (Snap 2)
-    // 2 DeletedRowsScanTask for fileA and fileB (Snap 3, since global delete disables pruning)
-    assertThat(tasks).hasSize(3);
-
-    long addedCount = tasks.stream().filter(t -> t instanceof AddedRowsScanTask).count();
-    long deletedCount = tasks.stream().filter(t -> t instanceof DeletedRowsScanTask).count();
-
-    assertThat(addedCount).isEqualTo(1);
-    assertThat(deletedCount).isEqualTo(2);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseIncrementalChangelogScan.java
@@ -21,7 +21,6 @@ package org.apache.iceberg;
 import static org.apache.iceberg.TableProperties.MANIFEST_MERGE_ENABLED;
 import static org.apache.iceberg.TableProperties.MANIFEST_MIN_MERGE_COUNT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -248,16 +247,701 @@ public class TestBaseIncrementalChangelogScan
   }
 
   @TestTemplate
-  public void testDeleteFilesAreNotSupported() {
+  public void testPositionDeletesOnExistingFile() {
     assumeThat(formatVersion).isEqualTo(2);
 
+    // Add initial data files
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedRowsScanTask for FILE_A
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testEqualityDeletesOnExistingFile() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add initial data files
     table.newFastAppend().appendFile(FILE_A2).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
 
+    // Add equality deletes for FILE_A2
     table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
 
-    assertThatThrownBy(() -> plan(newScan()))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Delete files are currently not supported in changelog scans");
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedRowsScanTask for FILE_A2
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task.existingDeletes()).as("Must have no existing deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testAddedFileWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add FILE_A with deletes
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Add FILE_B in the changelog range
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one AddedRowsScanTask for FILE_B (no deletes apply to FILE_B)
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+    assertThat(task.deletes()).as("Must have no deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Add deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Delete FILE_A in the changelog range
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedDataFileScanTask for FILE_A with existing deletes
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes())
+        .as("Must have existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testMultipleSnapshotsWithDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add FILE_C
+    table.newFastAppend().appendFile(FILE_C).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Add deletes for FILE_B
+    DeleteFile fileBDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-b-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileBDeletes).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A (snap2)
+    // 2. AddedRowsScanTask for FILE_C (snap3)
+    // 3. DeletedRowsScanTask for FILE_B (snap4)
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
+
+    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_C.location());
+
+    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+    assertThat(task3.addedDeletes()).as("Must have added deletes").hasSize(1);
+  }
+
+  @TestTemplate
+  public void testInsertDeleteReinsert() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Insert FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete for FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Re-insert FILE_A (same file, new snapshot)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A affected by delete (snap2)
+    // 2. AddedRowsScanTask for FILE_A re-insert (snap3)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes()).as("Must have added deletes").hasSize(1);
+
+    AddedRowsScanTask task2 = (AddedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // The re-inserted file is a fresh insert, so the deletes from snap2 were already
+    // accounted for in the DeletedRowsScanTask above
+    assertThat(task2.deletes()).as("Re-insert should not carry previous deletes").isEmpty();
+  }
+
+  @TestTemplate
+  public void testInsertAndDeleteInSameCommit() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: baseline
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add FILE_A and delete it in the same commit (using row delta)
+    table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should emit an AddedRowsScanTask with deletes attached
+    // The net result depends on whether all rows are deleted
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    AddedRowsScanTask task = (AddedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap2.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // The delete should be attached to the added file task
+    assertThat(task.deletes())
+        .as("Must have deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testOverlappingEqualityAndPositionDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes that also affect FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 2 DeletedRowsScanTask for FILE_A (one per snapshot with deletes)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have 1 added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have 1 added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    // The position delete from snap2 should be an existing delete for snap3
+    assertThat(task2.existingDeletes())
+        .as("Must be 1 position delete from previous snapshot")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testEqualityDeleteOverlapsEqualityDelete() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A2 (has equality delete support)
+    table.newFastAppend().appendFile(FILE_A2).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete on field 'id'
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality delete on different field 'data' that matches the same logical rows
+    // This tests behavior when two equality deletes on different columns target overlapping
+    // rows
+    DeleteFile eqDeleteOnData =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-data.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeleteOnData).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 2 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
+    // This documents current behavior - whether duplicate DELETE rows are emitted or deduplicated
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have first equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have second equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDeleteOnData.location());
+    // First equality delete should be an existing delete for the second task
+    assertThat(task2.existingDeletes())
+        .as("Must have first equality delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithBothDeleteTypes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes for FILE_A (potentially overlapping)
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Delete FILE_A entirely
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. DeletedRowsScanTask for FILE_A with position deletes (snap2)
+    // 2. DeletedRowsScanTask for FILE_A with equality deletes (snap3)
+    // 3. DeletedDataFileScanTask for FILE_A deletion (snap4) with both types of existing deletes
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have position deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have equality deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    // Position delete from snap2 should be an existing delete for snap3
+    assertThat(task2.existingDeletes())
+        .as("Must have position delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+
+    DeletedDataFileScanTask task3 = (DeletedDataFileScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // When file is deleted, all existing deletes should be included to omit previously deleted rows
+    assertThat(task3.existingDeletes())
+        .as("Must have both position and equality deletes as existing")
+        .hasSize(2)
+        .extracting(DeleteFile::location)
+        .containsExactlyInAnyOrder(FILE_A_DELETES.location(), FILE_A2_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testMultipleEqualityDeletesSameFile() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A2
+    table.newFastAppend().appendFile(FILE_A2).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality delete #1 on field 'id'
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality delete #2 on field 'id' (different values, no overlap)
+    DeleteFile eqDelete2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDelete2).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Snapshot 4: Add equality delete #3 on field 'data' (potentially overlaps with delete #1 or
+    // #2)
+    DeleteFile eqDelete3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-3.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDelete3).commit();
+    Snapshot snap4 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap4.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 3 DeletedRowsScanTask for FILE_A2 (one per snapshot with deletes)
+    // This documents cumulative equality delete tracking across multiple snapshots
+    assertThat(tasks).as("Must have 3 tasks").hasSize(3);
+
+    DeletedRowsScanTask task1 = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task1.addedDeletes())
+        .as("Must have first equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task1.existingDeletes()).as("Must have no existing deletes").isEmpty();
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have second equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete2.location());
+    // First equality delete should be an existing delete for the second task
+    assertThat(task2.existingDeletes())
+        .as("Must have first equality delete as existing")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+
+    DeletedRowsScanTask task3 = (DeletedRowsScanTask) tasks.get(2);
+    assertThat(task3.changeOrdinal()).as("Ordinal must match").isEqualTo(2);
+    assertThat(task3.file().location()).as("Data file must match").isEqualTo(FILE_A2.location());
+    assertThat(task3.addedDeletes())
+        .as("Must have third equality delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete3.location());
+    // Both previous equality deletes should be existing deletes for the third task
+    assertThat(task3.existingDeletes())
+        .as("Must have both previous equality deletes as existing")
+        .hasSize(2)
+        .extracting(DeleteFile::location)
+        .containsExactlyInAnyOrder(FILE_A2_DELETES.location(), eqDelete2.location());
+  }
+
+  @TestTemplate
+  public void testExistingAndNewDeletesBothApplied() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A with position deletes
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add FILE_B
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add equality deletes affecting FILE_A
+    table.newRowDelta().addDeletes(FILE_A2_DELETES).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have:
+    // 1. AddedRowsScanTask for FILE_B (snap2)
+    // 2. DeletedRowsScanTask for FILE_A with new equality delete (snap3)
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    AddedRowsScanTask task1 = (AddedRowsScanTask) tasks.get(0);
+    assertThat(task1.changeOrdinal()).as("Ordinal must match").isEqualTo(0);
+    assertThat(task1.file().location()).as("Data file must match").isEqualTo(FILE_B.location());
+
+    DeletedRowsScanTask task2 = (DeletedRowsScanTask) tasks.get(1);
+    assertThat(task2.changeOrdinal()).as("Ordinal must match").isEqualTo(1);
+    assertThat(task2.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    assertThat(task2.addedDeletes())
+        .as("Must have newly added delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A2_DELETES.location());
+    assertThat(task2.existingDeletes())
+        .as("Must have existing delete")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testOverwriteSnapshotWithExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B with deletes on FILE_A
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Overwrite - replace FILE_A with FILE_A2, keep FILE_B
+    table.newOverwrite().addFile(FILE_A2).deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    // Should not throw NPE and should handle the overwrite correctly
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // The overwrite creates ADDED and DELETED tasks
+    assertThat(tasks).as("Must have 2 tasks").hasSize(2);
+
+    AddedRowsScanTask addedTask = (AddedRowsScanTask) tasks.get(0);
+    assertThat(addedTask.file().location())
+        .as("Added file must match")
+        .isEqualTo(FILE_A2.location());
+
+    DeletedDataFileScanTask deletedTask = (DeletedDataFileScanTask) tasks.get(1);
+    assertThat(deletedTask.file().location())
+        .as("Deleted file must match")
+        .isEqualTo(FILE_A.location());
+    // FILE_A had existing deletes which should be included
+    assertThat(deletedTask.existingDeletes())
+        .as("Must have existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testDeletedFileWithPreScanRangeDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add deletes for FILE_A (before scan range)
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_A entirely (within scan range)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // Scan from snap2 (exclusive) to snap3
+    // This means the delete of FILE_A happens within the range,
+    // but the delete file (FILE_A_DELETES) was added before the range
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have one DeletedDataFileScanTask for FILE_A
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.commitSnapshotId()).as("Snapshot must match").isEqualTo(snap3.snapshotId());
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+
+    // The key assertion: existingDeletes should include FILE_A_DELETES
+    // so consumers know to omit those previously deleted rows
+    assertThat(task.existingDeletes())
+        .as("Must include pre-existing deletes to omit previously deleted rows")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
+  @TestTemplate
+  public void testLargeDeleteSetWithPruning() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A in partition 0
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add large equality delete set, but only affecting partition 0
+    // Create multiple equality delete files for different partitions
+    DeleteFile eqDelete1 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-1.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(100)
+            .build();
+
+    DeleteFile eqDelete2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(100)
+            .build();
+
+    DeleteFile eqDelete3 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/eq-delete-3.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=2")
+            .withRecordCount(100)
+            .build();
+
+    table.newRowDelta().addDeletes(eqDelete1).addDeletes(eqDelete2).addDeletes(eqDelete3).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have 1 DeletedRowsScanTask for FILE_A
+    // Only eqDelete1 should be included (partition 0), not eqDelete2 or eqDelete3
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) Iterables.getOnlyElement(tasks);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+    // Should only have 1 delete file (the one in partition 0)
+    // The DeleteFileIndex should prune out the other partition's delete files
+    assertThat(task.addedDeletes())
+        .as("Must have only 1 delete (partition pruning should eliminate others)")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(eqDelete1.location());
   }
 
   // plans tasks and reorders them to have deterministic order
@@ -272,6 +956,45 @@ public class TestBaseIncrementalChangelogScan
     }
   }
 
+  @TestTemplate
+  public void testDeleteFilePartitionPruning() throws IOException {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A (partition 0)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add delete files for FILE_A (partition 0) and FILE_C (partition 2)
+    // FILE_C is not present as a data file, only its delete file
+    table.newRowDelta().addDeletes(FILE_A_DELETES).addDeletes(FILE_C2_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Scan without filter
+    // Partition pruning will automatically exclude FILE_C2_DELETES because:
+    // 1. There's no data file in partition 2 (FILE_C doesn't exist)
+    // 2. The delete file's partition doesn't overlap with any existing data files
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Should have a DeletedRowsScanTask for FILE_A only
+    assertThat(tasks).as("Must have 1 task").hasSize(1);
+
+    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task.file().location()).as("Data file must match").isEqualTo(FILE_A.location());
+
+    // Verify that only FILE_A_DELETES is included (partition 0)
+    // FILE_C2_DELETES should have been pruned because:
+    // - Its partition (data_bucket=2) doesn't contain any data files
+    // - The partition pruning optimization skips it during accumulation
+    assertThat(task.addedDeletes())
+        .as("Must have added deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+  }
+
   private Comparator<? super ChangelogScanTask> taskComparator() {
     return (t1, t2) ->
         ComparisonChain.start()
@@ -283,5 +1006,363 @@ public class TestBaseIncrementalChangelogScan
 
   private String path(ChangelogScanTask task) {
     return ((ContentScanTask<?>) task).file().location().toString();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexAppendOnly() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Scenario 1: Append-only with position deletes (no equality deletes, no DELETED files)
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add position deletes for FILE_A
+    // This creates a DeletedRowsScanTask for EXISTING file FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan1 =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks1 = plan(scan1);
+
+    // Verify no errors and correct results
+    assertThat(tasks1).isNotEmpty();
+
+    // Verify existingDeleteIndex was NOT built (position deletes don't require it)
+    BaseIncrementalChangelogScan baseScan1 = (BaseIncrementalChangelogScan) scan1;
+    assertThat(baseScan1.getExistingDeleteIndexBuildCallCount())
+        .as(
+            "Should not call buildExistingDeleteIndex for position deletes without equality deletes/DELETED files")
+        .isEqualTo(0);
+    assertThat(baseScan1.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should not build existingDeleteIndex for position deletes without equality deletes/DELETED files")
+        .isFalse();
+
+    // Scenario 2: Pure append-only (no deletes at all, no DELETED files)
+    // Snapshot 3: Add FILE_B (pure append, no deletes)
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan2 =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks2 = plan(scan2);
+
+    // Verify correct results
+    assertThat(tasks2).hasSize(1);
+    AddedRowsScanTask task = (AddedRowsScanTask) tasks2.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_B.location());
+
+    // Verify existingDeleteIndex was NOT built (pure append, no deletes, no DELETED files)
+    BaseIncrementalChangelogScan baseScan2 = (BaseIncrementalChangelogScan) scan2;
+    assertThat(baseScan2.getExistingDeleteIndexBuildCallCount())
+        .as("Should not call buildExistingDeleteIndex for pure append-only workload")
+        .isEqualTo(0);
+    assertThat(baseScan2.wasExistingDeleteIndexBuilt())
+        .as("Should not build existingDeleteIndex for pure append-only workload")
+        .isFalse();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithEqualityDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
+    DeleteFile eqDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).isNotEmpty();
+    DeletedRowsScanTask task = (DeletedRowsScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+
+    // Verify existingDeleteIndex was built EARLY (for equality deletes, not lazily)
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once for equality deletes")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as("Should build existingDeleteIndex early when equality deletes exist")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithDeletedFiles() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    // Snapshot 2: Add deletes for FILE_A (before scan range)
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_A entirely (within scan range, no equality deletes)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).hasSize(1);
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes())
+        .as("Must include pre-existing deletes")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(FILE_A_DELETES.location());
+
+    // Verify existingDeleteIndex was built LAZILY (on-demand for DELETED file)
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once (lazily) for DELETED file")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as("Should build existingDeleteIndex lazily when DELETED file is encountered")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexWithBothEqualityDeletesAndDeletedFiles() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A and FILE_B
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add equality deletes for FILE_A (triggers early building)
+    DeleteFile eqDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes()
+            .withPath("/path/to/eq-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(eqDeletes).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Delete FILE_B (different file) - this will trigger Supplier.get()
+    table.newDelete().deleteFile(FILE_B).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).isNotEmpty();
+
+    // This proves that the cached index was reused when DELETED file was encountered
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as(
+            "Should call buildExistingDeleteIndex exactly once (early), then reuse cached index for DELETED file")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should build existingDeleteIndex early when equality deletes exist, even with DELETED files")
+        .isTrue();
+
+    // ensure DELETED file task has correct deletes
+    DeletedDataFileScanTask deletedTask =
+        tasks.stream()
+            .filter(t -> t instanceof DeletedDataFileScanTask)
+            .map(t -> (DeletedDataFileScanTask) t)
+            .findFirst()
+            .orElse(null);
+    if (deletedTask != null) {
+      assertThat(deletedTask.file().location()).isEqualTo(FILE_B.location());
+    }
+  }
+
+  @TestTemplate
+  public void testLazyExistingDeleteIndexNoExistingDeletes() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Snapshot 1: Add FILE_A (before scan range)
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Delete FILE_A (within scan range, no existing deletes, no equality deletes)
+    table.newDelete().deleteFile(FILE_A).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap1.snapshotId()).toSnapshot(snap2.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Verify correct results
+    assertThat(tasks).hasSize(1);
+    DeletedDataFileScanTask task = (DeletedDataFileScanTask) tasks.get(0);
+    assertThat(task.file().location()).isEqualTo(FILE_A.location());
+    assertThat(task.existingDeletes()).isEmpty();
+
+    // Verify existingDeleteIndex was built (lazily for DELETED file, even though no existing
+    // deletes)
+    // Note: It will be built but will be empty
+    BaseIncrementalChangelogScan baseScan = (BaseIncrementalChangelogScan) scan;
+    assertThat(baseScan.getExistingDeleteIndexBuildCallCount())
+        .as("Should call buildExistingDeleteIndex exactly once (lazily) even if result is empty")
+        .isEqualTo(1);
+    assertThat(baseScan.wasExistingDeleteIndexBuilt())
+        .as(
+            "Should build existingDeleteIndex when DELETED file is encountered, even with no existing deletes")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testMixedDeleteManifestEntries() {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    table
+        .updateProperties()
+        .set(MANIFEST_MIN_MERGE_COUNT, "1")
+        .set(MANIFEST_MERGE_ENABLED, "true")
+        .commit();
+
+    // Snapshot 1: Add FILE_A
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    // Snapshot 2: Add Delete 1 for FILE_A
+    table.newRowDelta().addDeletes(FILE_A_DELETES).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Snapshot 3: Add Delete 2 for FILE_A
+    DeleteFile fileADeletes2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/data-a-deletes-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(1)
+            .build();
+    table.newRowDelta().addDeletes(fileADeletes2).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    // We scan from snap2 to snap3 (meaning we only care about snap3's changes).
+    IncrementalChangelogScan scan =
+        newScan().fromSnapshotExclusive(snap2.snapshotId()).toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    assertThat(tasks).isNotEmpty();
+
+    // Find the task for snap3
+    DeletedRowsScanTask snap3Task =
+        tasks.stream()
+            .filter(
+                t -> t instanceof DeletedRowsScanTask && t.commitSnapshotId() == snap3.snapshotId())
+            .map(t -> (DeletedRowsScanTask) t)
+            .findFirst()
+            .orElse(null);
+
+    assertThat(snap3Task).isNotNull();
+    assertThat(snap3Task.addedDeletes())
+        .as("Must only contain the new delete from snap3")
+        .hasSize(1)
+        .extracting(DeleteFile::location)
+        .containsExactly(fileADeletes2.location());
+  }
+
+  @TestTemplate
+  public void testUnpartitionedEqualityDeletePruning() throws Exception {
+    assumeThat(formatVersion).isEqualTo(2);
+
+    // Create a new table specifically for this test, starting unpartitioned (Spec ID 0)
+    String tableName =
+        "test_unpartitioned_pruning_" + java.util.UUID.randomUUID().toString().replace("-", "");
+    TestTables.TestTable localTable =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, PartitionSpec.unpartitioned(), formatVersion);
+
+    // Snapshot 1: Add fileA (unpartitioned, Spec ID 0)
+    DataFile fileA =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(localTable.location() + "/data-unpartitioned-a.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    localTable.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = localTable.currentSnapshot();
+
+    // Evolve spec to bucketed (Spec ID 1)
+    localTable
+        .updateSpec()
+        .addField(org.apache.iceberg.expressions.Expressions.bucket("data", 16))
+        .commit();
+    PartitionSpec bucketedSpec = localTable.spec();
+
+    // Snapshot 2: Add fileB (bucketed, Spec ID 1)
+    String bucketFieldName = bucketedSpec.fields().get(0).name();
+    DataFile fileB =
+        DataFiles.builder(bucketedSpec)
+            .withPath(localTable.location() + "/data-bucketed-b.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath(bucketFieldName + "=1")
+            .withRecordCount(1)
+            .build();
+    localTable.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = localTable.currentSnapshot();
+
+    // Snapshot 3: Create an unpartitioned equality delete (Spec ID 0)
+    int idFieldId = localTable.schema().findField("id").fieldId();
+    DeleteFile globalDelete =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofEqualityDeletes(idFieldId)
+            .withPath(localTable.location() + "/global-delete.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    localTable.newRowDelta().addDeletes(globalDelete).commit();
+    Snapshot snap3 = localTable.currentSnapshot();
+
+    // Scan from snap1 exclusive to snap3 using localTable
+    IncrementalChangelogScan scan =
+        localTable
+            .newIncrementalChangelogScan()
+            .fromSnapshotExclusive(snap1.snapshotId())
+            .toSnapshot(snap3.snapshotId());
+
+    List<ChangelogScanTask> tasks = plan(scan);
+
+    // Expecting 3 tasks:
+    // 1 AddedRowsScanTask for fileB (Snap 2)
+    // 2 DeletedRowsScanTask for fileA and fileB (Snap 3, since global delete disables pruning)
+    assertThat(tasks).hasSize(3);
+
+    long addedCount = tasks.stream().filter(t -> t instanceof AddedRowsScanTask).count();
+    long deletedCount = tasks.stream().filter(t -> t instanceof DeletedRowsScanTask).count();
+
+    assertThat(addedCount).isEqualTo(1);
+    assertThat(deletedCount).isEqualTo(2);
   }
 }


### PR DESCRIPTION
## Summary

This narrows the changelog scan delete-file support from Apache Iceberg PR 14264 to deletion vectors only.

- Supports Puffin deletion vectors for v3 tables in incremental changelog scans.
- Rejects equality deletes and non-DV position deletes with a clear unsupported-delete message.
- Carries matching deletion-vector context for added data files, removed data files, and deleted-row tasks.

## Validation

- `env GRADLE_USER_HOME=/tmp/gradle ./gradlew :iceberg-core:test --tests org.apache.iceberg.TestBaseIncrementalChangelogScan`
- `env GRADLE_USER_HOME=/tmp/gradle ./gradlew :iceberg-core:spotlessJavaCheck`