### PR TITLE
Spark 4.1: Fix view rename target namespace

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -79,6 +79,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -108,6 +113,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -82,6 +82,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
         flink: ['1.20', '2.0', '2.1']
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -80,6 +80,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -75,6 +75,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -104,6 +109,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
@@ -124,6 +134,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -80,6 +80,11 @@ jobs:
       max-parallel: 15
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
+        exclude:
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -82,6 +82,7 @@ jobs:
       max-parallel: 20
       matrix:
         jvm: [17, 21]
+        event_name: ['${{ github.event_name }}']
         spark: ['3.5', '4.0', '4.1']
         scala: ['2.12', '2.13']
         # Split iceberg-spark (core) from iceberg-spark-extensions/-runtime
@@ -94,6 +95,9 @@ jobs:
             scala: '2.12'
           - spark: '4.1'
             scala: '2.12'
+          # Pull requests run the baseline JDK only.
+          - event_name: pull_request
+            jvm: 21
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -565,6 +565,9 @@ acceptedBreaks:
       old: "field org.apache.iceberg.PartitionStatsHandler.PARTITION_FIELD_NAME"
       justification: "Removed deprecated functionality for partition stats"
     - code: "java.method.removed"
+      old: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::forPositionDelete(org.apache.iceberg.Table)"
+      justification: "Deprecated for removal in 1.12.0"
+    - code: "java.method.removed"
       old: "method org.apache.iceberg.Schema org.apache.iceberg.PartitionStatsHandler::schema(org.apache.iceberg.types.Types.StructType,\
         \ int)"
       justification: "Removed deprecated functionality for partition stats"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,9 @@ The `api/` module has the strongest stability guarantees — breaking changes ar
 - 2 spaces indent, 4 spaces continuation. Empty newline after control flow blocks.
 - Use `this.` for instance field assignment. `Preconditions` calls first in methods.
 - No `final` on locals. No one-argument-per-line unless necessary.
-- Magic numbers should be named constants. No personal pronouns in comments.
-- Javadoc describes the function or purpose of a class or method, not the implementation. Only describe what callers need to use the component, as though it were defined by an interface. Don't leak implementation details — over-documenting creates churn when the implementation changes.
+- Magic numbers should be named constants. No personal pronouns in comments. Comments should explain non-obvious intent or constraints; don't restate what the code already says.
+- Javadoc describes the function or purpose of a class or method, not the implementation. For public APIs, keep it brief and describe only what callers need to use the component, as though it were defined by an interface. Don't leak implementation details.
+- Comments and Javadocs should describe the current behavior or contract, not how it changed over time.
 - `} else {` on same line. Minimize variable scope. `try-with-resources` for all `AutoCloseable`.
 - Prefer method references over lambdas. Wrap lines at the highest semantic level.
 - Always use imports — never use fully-qualified class names inline.

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -48,13 +48,6 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         Serializable {
 
   static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
-  static final PartitionData EMPTY_PARTITION_DATA =
-      new PartitionData(EMPTY_STRUCT_TYPE) {
-        @Override
-        public PartitionData copy() {
-          return this; // this does not change
-        }
-      };
 
   private Types.StructType partitionType;
 
@@ -171,8 +164,8 @@ abstract class BaseFile<F> extends SupportsIndexProjection
 
     // this constructor is used by DataFiles.Builder, which passes null for unpartitioned data
     if (partition == null) {
-      this.partitionData = EMPTY_PARTITION_DATA;
-      this.partitionType = EMPTY_PARTITION_DATA.getPartitionType();
+      this.partitionData = PartitionData.EMPTY;
+      this.partitionType = PartitionData.EMPTY.getPartitionType();
     } else {
       this.partitionData = partition;
       this.partitionType = partition.getPartitionType();

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -32,7 +32,7 @@ import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.apache.iceberg.MetricsModes.MetricsMode;
 import org.apache.iceberg.exceptions.ValidationException;
-import org.apache.iceberg.relocated.com.google.common.base.Joiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -49,12 +49,12 @@ import org.slf4j.LoggerFactory;
 public final class MetricsConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
-  private static final Joiner DOT = Joiner.on('.');
 
   // Disable metrics by default for wide tables to prevent excessive metadata
   private static final MetricsMode DEFAULT_MODE =
       MetricsModes.fromString(DEFAULT_WRITE_METRICS_MODE_DEFAULT);
-  private static final MetricsConfig DEFAULT = new MetricsConfig(ImmutableMap.of(), DEFAULT_MODE);
+  private static final MetricsConfig DEFAULT =
+      new MetricsConfig(ImmutableMap.of(), DEFAULT_MODE, ImmutableMap.of());
   private static final MetricsConfig POSITION_DELETE_MODE =
       new MetricsConfig(
           ImmutableMap.of(
@@ -62,14 +62,24 @@ public final class MetricsConfig implements Serializable {
               MetricsModes.Full.get(),
               MetadataColumns.DELETE_FILE_POS.name(),
               MetricsModes.Full.get()),
-          DEFAULT_MODE);
+          MetricsModes.None.get(),
+          ImmutableMap.of(
+              MetadataColumns.DELETE_FILE_PATH.fieldId(),
+              MetadataColumns.DELETE_FILE_PATH.name(),
+              MetadataColumns.DELETE_FILE_POS.fieldId(),
+              MetadataColumns.DELETE_FILE_POS.name()));
 
   private final Map<String, MetricsMode> columnModes;
   private final MetricsMode defaultMode;
+  private final Map<Integer, String> idToName;
 
-  private MetricsConfig(Map<String, MetricsMode> columnModes, MetricsMode defaultMode) {
+  private MetricsConfig(
+      Map<String, MetricsMode> columnModes,
+      MetricsMode defaultMode,
+      Map<Integer, String> idToName) {
     this.columnModes = SerializableMap.copyOf(columnModes).immutableMap();
     this.defaultMode = defaultMode;
+    this.idToName = idToName != null ? SerializableMap.copyOf(idToName).immutableMap() : null;
   }
 
   public static MetricsConfig getDefault() {
@@ -84,11 +94,21 @@ public final class MetricsConfig implements Serializable {
    * Creates a metrics config from table configuration.
    *
    * @param props table configuration
-   * @deprecated use {@link MetricsConfig#forTable(Table)}. Will be removed in 2.0.0
+   * @deprecated use {@link MetricsConfig#forTable(Table)}. Will be removed in 1.13.0
    */
   @Deprecated
   public static MetricsConfig fromProperties(Map<String, String> props) {
     return from(props, null, null);
+  }
+
+  /**
+   * Validates metrics config properties with the given schema.
+   *
+   * @param props table properties
+   * @param schema table schema
+   */
+  public static void validate(Map<String, String> props, Schema schema) {
+    from(props, schema, null).validateReferencedColumns(schema);
   }
 
   /**
@@ -100,32 +120,42 @@ public final class MetricsConfig implements Serializable {
     return from(table.properties(), table.schema(), table.sortOrder());
   }
 
-  /**
-   * Creates a metrics config for a position delete file.
-   *
-   * @param table an Iceberg table
-   * @deprecated This method is deprecated as of version 1.11.0 and will be removed in 1.12.0.
-   *     Position deletes that include row data are no longer supported. Use {@link
-   *     #forPositionDelete()} instead.
-   */
-  @Deprecated
-  public static MetricsConfig forPositionDelete(Table table) {
-    ImmutableMap.Builder<String, MetricsMode> columnModes = ImmutableMap.builder();
+  public Iterable<Integer> metricsFieldIds() {
+    Preconditions.checkState(idToName != null, "Cannot resolve column mode by ID: missing schema");
+    return idToName.keySet();
+  }
 
-    columnModes.put(MetadataColumns.DELETE_FILE_PATH.name(), MetricsModes.Full.get());
-    columnModes.put(MetadataColumns.DELETE_FILE_POS.name(), MetricsModes.Full.get());
+  public MetricsMode columnMode(int id) {
+    Preconditions.checkState(idToName != null, "Cannot resolve column mode by ID: missing schema");
+    String name = idToName.get(id);
+    if (name != null) {
+      return columnMode(name);
+    }
 
-    MetricsConfig tableConfig = forTable(table);
+    return defaultMode;
+  }
 
-    MetricsMode defaultMode = tableConfig.defaultMode;
-    tableConfig.columnModes.forEach(
-        (columnAlias, mode) -> {
-          String positionDeleteColumnAlias =
-              DOT.join(MetadataColumns.DELETE_FILE_ROW_FIELD_NAME, columnAlias);
-          columnModes.put(positionDeleteColumnAlias, mode);
-        });
+  public MetricsMode columnMode(String columnAlias) {
+    return columnModes.getOrDefault(columnAlias, defaultMode);
+  }
 
-    return new MetricsConfig(columnModes.build(), defaultMode);
+  public void validateReferencedColumns(Schema schema) {
+    for (String column : columnModes.keySet()) {
+      Types.NestedField field = schema.findField(column);
+      ValidationException.check(
+          field != null,
+          "Invalid metrics config, could not find column %s from table prop %s in schema %s",
+          column,
+          METRICS_MODE_COLUMN_CONF_PREFIX + column,
+          schema);
+
+      ValidationException.check(
+          null == idToName || column.equals(idToName.get(field.fieldId())),
+          "Incorrect field name for id %s: %s (expected %s)",
+          field.fieldId(),
+          column,
+          idToName.get(field.fieldId()));
+    }
   }
 
   static Set<Integer> limitFieldIds(Schema schema, int limit) {
@@ -225,6 +255,7 @@ public final class MetricsConfig implements Serializable {
    */
   public static MetricsConfig from(Map<String, String> props, Schema schema, SortOrder order) {
     int maxInferredDefaultColumns = maxInferredColumnDefaults(props);
+    Map<Integer, String> idToName = Maps.newHashMap();
     Map<String, MetricsMode> columnModes = Maps.newHashMap();
 
     // Handle user override of default mode
@@ -237,13 +268,20 @@ public final class MetricsConfig implements Serializable {
     } else if (schema == null) {
       defaultMode = DEFAULT_MODE;
     } else {
-      if (TypeUtil.getProjectedIds(schema).size() <= maxInferredDefaultColumns) {
+      Set<Integer> ids = TypeUtil.getProjectedIds(schema);
+      if (ids.size() <= maxInferredDefaultColumns) {
+        for (int id : ids) {
+          idToName.put(id, schema.findColumnName(id));
+        }
+
         // there are less than the inferred limit (including structs), so the default is used
         // everywhere
         defaultMode = DEFAULT_MODE;
       } else {
         for (Integer id : limitFieldIds(schema, maxInferredDefaultColumns)) {
-          columnModes.put(schema.findColumnName(id), DEFAULT_MODE);
+          String name = schema.findColumnName(id);
+          idToName.put(id, name);
+          columnModes.put(name, DEFAULT_MODE);
         }
 
         // all other columns don't use metrics
@@ -254,7 +292,14 @@ public final class MetricsConfig implements Serializable {
     // First set sorted column with sorted column default (can be overridden by user)
     MetricsMode sortedColDefaultMode = sortedColumnDefaultMode(defaultMode);
     Set<String> sortedCols = SortOrderUtil.orderPreservingSortedColumns(order);
-    sortedCols.forEach(sc -> columnModes.put(sc, sortedColDefaultMode));
+    sortedCols.forEach(
+        name -> {
+          columnModes.put(name, sortedColDefaultMode);
+          Types.NestedField field = schema != null ? schema.findField(name) : null;
+          if (field != null) {
+            idToName.put(field.fieldId(), name);
+          }
+        });
 
     // Handle user overrides of defaults
     for (String key : props.keySet()) {
@@ -262,10 +307,14 @@ public final class MetricsConfig implements Serializable {
         String columnAlias = key.replaceFirst(METRICS_MODE_COLUMN_CONF_PREFIX, "");
         MetricsMode mode = parseMode(props.get(key), defaultMode, "column " + columnAlias);
         columnModes.put(columnAlias, mode);
+        Types.NestedField field = schema != null ? schema.findField(columnAlias) : null;
+        if (field != null) {
+          idToName.put(field.fieldId(), columnAlias);
+        }
       }
     }
 
-    return new MetricsConfig(columnModes, defaultMode);
+    return new MetricsConfig(columnModes, defaultMode, idToName);
   }
 
   /**
@@ -308,20 +357,5 @@ public final class MetricsConfig implements Serializable {
       LOG.warn("Ignoring invalid metrics mode ({}): {}", context, modeString, err);
       return fallback;
     }
-  }
-
-  public void validateReferencedColumns(Schema schema) {
-    for (String column : columnModes.keySet()) {
-      ValidationException.check(
-          schema.findField(column) != null,
-          "Invalid metrics config, could not find column %s from table prop %s in schema %s",
-          column,
-          METRICS_MODE_COLUMN_CONF_PREFIX + column,
-          schema);
-    }
-  }
-
-  public MetricsMode columnMode(String columnAlias) {
-    return columnModes.getOrDefault(columnAlias, defaultMode);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -59,7 +59,12 @@ public class MetricsModes {
    *
    * <p>Implementations must be immutable.
    */
-  public interface MetricsMode extends Serializable {}
+  public interface MetricsMode extends Serializable {
+    default boolean hasBounds() {
+      throw new UnsupportedOperationException(
+          "Unexpected implementation of MetricsMode without hasBounds");
+    }
+  }
 
   /**
    * Under this mode, value_counts, null_value_counts, nan_value_counts, lower_bounds, upper_bounds
@@ -70,6 +75,11 @@ public class MetricsModes {
 
     public static None get() {
       return INSTANCE;
+    }
+
+    @Override
+    public boolean hasBounds() {
+      return false;
     }
 
     @Override
@@ -84,6 +94,11 @@ public class MetricsModes {
 
     public static Counts get() {
       return INSTANCE;
+    }
+
+    @Override
+    public boolean hasBounds() {
+      return false;
     }
 
     @Override
@@ -106,6 +121,11 @@ public class MetricsModes {
     public static Truncate withLength(int length) {
       Preconditions.checkArgument(length > 0, "Truncate length should be positive");
       return new Truncate(length);
+    }
+
+    @Override
+    public boolean hasBounds() {
+      return true;
     }
 
     public int length() {
@@ -143,6 +163,11 @@ public class MetricsModes {
 
     public static Full get() {
       return INSTANCE;
+    }
+
+    @Override
+    public boolean hasBounds() {
+      return true;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -553,64 +552,5 @@ public class MetricsUtil {
     }
 
     return result.isEmpty() ? null : Collections.unmodifiableMap(result);
-  }
-
-  static ContentStats fromMetrics(Schema schema, Metrics metrics) {
-    if (null == metrics) {
-      return null;
-    }
-
-    BaseContentStats.Builder builder = BaseContentStats.builder().withTableSchema(schema);
-    Map<Integer, BaseFieldStats.Builder<Object>> map = Maps.newHashMap();
-    mergeCountMetric(map, metrics.valueCounts(), BaseFieldStats.Builder::valueCount);
-    mergeCountMetric(map, metrics.nullValueCounts(), BaseFieldStats.Builder::nullValueCount);
-    mergeCountMetric(map, metrics.nanValueCounts(), BaseFieldStats.Builder::nanValueCount);
-    mergeBoundMetric(
-        map, metrics.lowerBounds(), metrics.originalTypes(), BaseFieldStats.Builder::lowerBound);
-    mergeBoundMetric(
-        map, metrics.upperBounds(), metrics.originalTypes(), BaseFieldStats.Builder::upperBound);
-
-    map.values().forEach(fieldStats -> builder.withFieldStats(fieldStats.build()));
-
-    return builder.build();
-  }
-
-  private static void mergeCountMetric(
-      Map<Integer, BaseFieldStats.Builder<Object>> fieldStatsById,
-      Map<Integer, Long> counts,
-      BiFunction<BaseFieldStats.Builder<Object>, Long, BaseFieldStats.Builder<Object>> setter) {
-    if (counts == null) {
-      return;
-    }
-
-    counts.forEach(
-        (id, value) ->
-            fieldStatsById.merge(
-                id,
-                setter.apply(BaseFieldStats.builder().fieldId(id), value),
-                (oldVal, newVal) -> setter.apply(oldVal, value)));
-  }
-
-  private static void mergeBoundMetric(
-      Map<Integer, BaseFieldStats.Builder<Object>> fieldStatsById,
-      Map<Integer, ByteBuffer> bounds,
-      Map<Integer, Type> originalTypes,
-      BiFunction<BaseFieldStats.Builder<Object>, Object, BaseFieldStats.Builder<Object>> setter) {
-    if (bounds == null || originalTypes == null) {
-      return;
-    }
-
-    bounds.entrySet().stream()
-        .filter(entry -> originalTypes.get(entry.getKey()) != null)
-        .forEach(
-            entry -> {
-              Integer id = entry.getKey();
-              Type type = originalTypes.get(id);
-              Object boundValue = Conversions.fromByteBuffer(type, entry.getValue());
-              fieldStatsById.merge(
-                  id,
-                  setter.apply(BaseFieldStats.builder().fieldId(id).type(type), boundValue),
-                  (oldVal, newVal) -> setter.apply(oldVal.type(type), boundValue));
-            });
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -38,6 +38,14 @@ import org.apache.iceberg.types.Types;
 public class PartitionData
     implements IndexedRecord, StructLike, SpecificData.SchemaConstructable, Serializable {
 
+  static final PartitionData EMPTY =
+      new PartitionData(Types.StructType.of()) {
+        @Override
+        public PartitionData copy() {
+          return this;
+        }
+      };
+
   static Schema partitionDataSchema(Types.StructType partitionType) {
     return AvroSchemaUtil.convert(partitionType, PartitionData.class.getName());
   }

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -90,7 +90,7 @@ class PropertiesUpdate implements UpdateProperties {
 
     // Validate the metrics
     if (base != null && base.schema() != null) {
-      MetricsConfig.fromProperties(newProperties).validateReferencedColumns(base.schema());
+      MetricsConfig.validate(newProperties, base.schema());
     }
 
     return newProperties;

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -139,7 +139,7 @@ public class TableMetadata implements Serializable {
 
     // Validate the metrics configuration. Note: we only do this on new tables to we don't
     // break existing tables.
-    MetricsConfig.fromProperties(properties).validateReferencedColumns(schema);
+    MetricsConfig.validate(properties, schema);
 
     PropertyUtil.validateCommitProperties(properties);
 

--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -106,7 +106,7 @@ interface TrackedFile {
         RECORD_COUNT,
         FILE_SIZE_IN_BYTES,
         SPEC_ID,
-        Types.NestedField.required(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC),
+        Types.NestedField.optional(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC),
         Types.NestedField.optional(
             CONTENT_STATS_ID, CONTENT_STATS_NAME, contentStatsType, CONTENT_STATS_DOC),
         SORT_ORDER_ID,
@@ -141,7 +141,7 @@ interface TrackedFile {
   /** Returns the ID of the partition spec used to partition this file, or null. */
   Integer specId();
 
-  /** Returns partition for this file as a {@link StructLike}. */
+  /** Returns partition for this file as a {@link StructLike}, or null. */
   StructLike partition();
 
   /** Returns the content stats for this entry. */

--- a/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileAdapters.java
@@ -100,7 +100,7 @@ class TrackedFileAdapters {
 
     @Override
     public StructLike partition() {
-      return file().partition();
+      return file().partition() != null ? file().partition() : PartitionData.EMPTY;
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -33,13 +33,6 @@ import org.apache.iceberg.util.ByteBuffers;
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
   private static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
-  private static final PartitionData EMPTY_PARTITION_DATA =
-      new PartitionData(EMPTY_STRUCT_TYPE) {
-        @Override
-        public PartitionData copy() {
-          return this; // this does not change
-        }
-      };
 
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
@@ -51,7 +44,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
           TrackedFile.RECORD_COUNT,
           TrackedFile.FILE_SIZE_IN_BYTES,
           TrackedFile.SPEC_ID,
-          Types.NestedField.required(
+          Types.NestedField.optional(
               TrackedFile.PARTITION_ID,
               TrackedFile.PARTITION_NAME,
               EMPTY_STRUCT_TYPE,
@@ -75,7 +68,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   private Tracking tracking = null;
   private long recordCount = -1L;
   private long fileSizeInBytes = -1L;
-  private PartitionData partitionData = EMPTY_PARTITION_DATA;
+  private PartitionData partitionData = null;
 
   // optional fields
   private Integer specId = null;
@@ -127,9 +120,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.fileFormat = fileFormat;
     this.recordCount = recordCount;
     this.fileSizeInBytes = fileSizeInBytes;
-    if (partition != null) {
-      this.partitionData = partition;
-    }
+    this.partitionData = partition;
 
     this.specId = specId;
     this.contentStats = contentStats;
@@ -151,7 +142,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.recordCount = toCopy.recordCount;
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.specId = toCopy.specId;
-    this.partitionData = toCopy.partitionData.copy();
+    this.partitionData = toCopy.partitionData != null ? toCopy.partitionData.copy() : null;
     this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
     this.sortOrderId = toCopy.sortOrderId;
     this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -92,8 +92,8 @@ public class TestFileGenerationUtil {
   @SuppressWarnings("deprecation")
   void testBoundsForAllMetricsModes(String metricsMode) {
     MetricsConfig metricsConfig =
-        MetricsConfig.fromProperties(
-            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode));
+        MetricsConfig.from(
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode), SCHEMA, null);
     Metrics metrics =
         FileGenerationUtil.generateRandomMetrics(
             SCHEMA,

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -326,7 +326,7 @@ public abstract class TestMetrics {
             MetricsModes.None.get().toString(),
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "nestedStructCol.longCol",
             MetricsModes.Full.get().toString());
-    MetricsConfig config = MetricsConfig.fromProperties(properties);
+    MetricsConfig config = MetricsConfig.from(properties, NESTED_SCHEMA, null);
 
     Metrics metrics = getMetrics(NESTED_SCHEMA, config, buildNestedTestRecord());
     MetricsWithStats metricsWithStats =
@@ -590,7 +590,8 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(
             NESTED_SCHEMA,
-            MetricsConfig.fromProperties(ImmutableMap.of("write.metadata.metrics.default", "none")),
+            MetricsConfig.from(
+                ImmutableMap.of("write.metadata.metrics.default", "none"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
     MetricsWithStats metricsWithStats =
         new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
@@ -613,8 +614,8 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(
             NESTED_SCHEMA,
-            MetricsConfig.fromProperties(
-                ImmutableMap.of("write.metadata.metrics.default", "counts")),
+            MetricsConfig.from(
+                ImmutableMap.of("write.metadata.metrics.default", "counts"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
     MetricsWithStats metricsWithStats =
         new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
@@ -638,7 +639,8 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(
             NESTED_SCHEMA,
-            MetricsConfig.fromProperties(ImmutableMap.of("write.metadata.metrics.default", "full")),
+            MetricsConfig.from(
+                ImmutableMap.of("write.metadata.metrics.default", "full"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
     MetricsWithStats metricsWithStats =
         new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
@@ -675,8 +677,10 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(
             singleStringColSchema,
-            MetricsConfig.fromProperties(
-                ImmutableMap.of("write.metadata.metrics.default", "truncate(10)")),
+            MetricsConfig.from(
+                ImmutableMap.of("write.metadata.metrics.default", "truncate(10)"),
+                singleStringColSchema,
+                null),
             record);
     MetricsWithStats metricsWithStats =
         new MetricsWithStats(metrics, MetricsUtil.fromMetrics(singleStringColSchema, metrics));
@@ -702,8 +706,10 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetrics(
             singleBinaryColSchema,
-            MetricsConfig.fromProperties(
-                ImmutableMap.of("write.metadata.metrics.default", "truncate(5)")),
+            MetricsConfig.from(
+                ImmutableMap.of("write.metadata.metrics.default", "truncate(5)"),
+                singleBinaryColSchema,
+                null),
             record);
     MetricsWithStats metricsWithStats =
         new MetricsWithStats(metrics, MetricsUtil.fromMetrics(singleBinaryColSchema, metrics));

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -166,22 +166,20 @@ public abstract class TestMetrics {
     record.setField("timestampColBelowEpoch", DateTimeUtil.timestampFromMicros(0L));
 
     Metrics metrics = getMetrics(SIMPLE_SCHEMA, record, record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(SIMPLE_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(2L);
-    assertCounts(1, 2L, 0L, metricsWithStats);
-    assertCounts(2, 2L, 0L, metricsWithStats);
-    assertCounts(3, 2L, 2L, metricsWithStats);
-    assertCounts(4, 2L, 0L, 2L, metricsWithStats);
-    assertCounts(5, 2L, 0L, 0L, metricsWithStats);
-    assertCounts(6, 2L, 0L, metricsWithStats);
-    assertCounts(7, 2L, 0L, metricsWithStats);
-    assertCounts(8, 2L, 0L, metricsWithStats);
-    assertCounts(9, 2L, 0L, metricsWithStats);
-    assertCounts(10, 2L, 0L, metricsWithStats);
-    assertCounts(11, 2L, 0L, metricsWithStats);
-    assertCounts(12, 2L, 0L, metricsWithStats);
-    assertCounts(13, 2L, 0L, metricsWithStats);
+    assertCounts(1, 2L, 0L, metrics);
+    assertCounts(2, 2L, 0L, metrics);
+    assertCounts(3, 2L, 2L, metrics);
+    assertCounts(4, 2L, 0L, 2L, metrics);
+    assertCounts(5, 2L, 0L, 0L, metrics);
+    assertCounts(6, 2L, 0L, metrics);
+    assertCounts(7, 2L, 0L, metrics);
+    assertCounts(8, 2L, 0L, metrics);
+    assertCounts(9, 2L, 0L, metrics);
+    assertCounts(10, 2L, 0L, metrics);
+    assertCounts(11, 2L, 0L, metrics);
+    assertCounts(12, 2L, 0L, metrics);
+    assertCounts(13, 2L, 0L, metrics);
   }
 
   @TestTemplate
@@ -216,54 +214,46 @@ public abstract class TestMetrics {
     secondRecord.setField("timestampColBelowEpoch", DateTimeUtil.timestampFromMicros(-7_000L));
 
     Metrics metrics = getMetrics(SIMPLE_SCHEMA, firstRecord, secondRecord);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(SIMPLE_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(2L);
-    assertCounts(1, 2L, 0L, metricsWithStats);
-    assertBounds(1, BooleanType.get(), false, true, metricsWithStats);
-    assertCounts(2, 2L, 0L, metricsWithStats);
-    assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, 3, metricsWithStats);
-    assertCounts(3, 2L, 1L, metricsWithStats);
-    assertBounds(3, LongType.get(), 5L, 5L, metricsWithStats);
-    assertCounts(4, 2L, 0L, 0L, metricsWithStats);
-    assertBounds(4, FloatType.get(), 1.0F, 2.0F, metricsWithStats);
-    assertCounts(5, 2L, 1L, 0L, metricsWithStats);
-    assertBounds(5, DoubleType.get(), 2.0D, 2.0D, metricsWithStats);
-    assertCounts(6, 2L, 1L, metricsWithStats);
+    assertCounts(1, 2L, 0L, metrics);
+    assertBounds(1, BooleanType.get(), false, true, metrics);
+    assertCounts(2, 2L, 0L, metrics);
+    assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, 3, metrics);
+    assertCounts(3, 2L, 1L, metrics);
+    assertBounds(3, LongType.get(), 5L, 5L, metrics);
+    assertCounts(4, 2L, 0L, 0L, metrics);
+    assertBounds(4, FloatType.get(), 1.0F, 2.0F, metrics);
+    assertCounts(5, 2L, 1L, 0L, metrics);
+    assertBounds(5, DoubleType.get(), 2.0D, 2.0D, metrics);
+    assertCounts(6, 2L, 1L, metrics);
+    assertBounds(6, DecimalType.of(10, 2), new BigDecimal("3.50"), new BigDecimal("3.50"), metrics);
+    assertCounts(7, 2L, 0L, metrics);
+    assertBounds(7, StringType.get(), CharBuffer.wrap("AAA"), CharBuffer.wrap("ZZZ"), metrics);
+    assertCounts(8, 2L, 1L, metrics);
+    assertBounds(8, DateType.get(), 1500, 1500, metrics);
+    assertCounts(9, 2L, 0L, metrics);
+    assertBounds(9, TimeType.get(), 2000L, 3000L, metrics);
+    assertCounts(10, 2L, 0L, metrics);
+    assertBounds(10, TimestampType.withoutZone(), 0L, 900L, metrics);
+    assertCounts(11, 2L, 0L, metrics);
     assertBounds(
-        6, DecimalType.of(10, 2), new BigDecimal("3.50"), new BigDecimal("3.50"), metricsWithStats);
-    assertCounts(7, 2L, 0L, metricsWithStats);
-    assertBounds(
-        7, StringType.get(), CharBuffer.wrap("AAA"), CharBuffer.wrap("ZZZ"), metricsWithStats);
-    assertCounts(8, 2L, 1L, metricsWithStats);
-    assertBounds(8, DateType.get(), 1500, 1500, metricsWithStats);
-    assertCounts(9, 2L, 0L, metricsWithStats);
-    assertBounds(9, TimeType.get(), 2000L, 3000L, metricsWithStats);
-    assertCounts(10, 2L, 0L, metricsWithStats);
-    assertBounds(10, TimestampType.withoutZone(), 0L, 900L, metricsWithStats);
-    assertCounts(11, 2L, 0L, metricsWithStats);
-    assertBounds(
-        11,
-        FixedType.ofLength(4),
-        ByteBuffer.wrap(fixed),
-        ByteBuffer.wrap(fixed),
-        metricsWithStats);
-    assertCounts(12, 2L, 0L, metricsWithStats);
+        11, FixedType.ofLength(4), ByteBuffer.wrap(fixed), ByteBuffer.wrap(fixed), metrics);
+    assertCounts(12, 2L, 0L, metrics);
     assertBounds(
         12,
         BinaryType.get(),
         ByteBuffer.wrap("S".getBytes()),
         ByteBuffer.wrap("W".getBytes()),
-        metricsWithStats);
+        metrics);
     if (fileFormat() == FileFormat.ORC) {
       // TODO: The special condition for ORC can be removed when ORC-342 is fixed
       // ORC-342: ORC writer creates inaccurate timestamp data and stats 1 sec below epoch
       // Values in the range `[1969-12-31 23:59:59.000,1969-12-31 23:59:59.999]` will have 1 sec
       // added to them
       // So the upper bound value of -7_000 micros becomes 993_000 micros
-      assertBounds(13, TimestampType.withoutZone(), -1_900_300L, 993_000L, metricsWithStats);
+      assertBounds(13, TimestampType.withoutZone(), -1_900_300L, 993_000L, metrics);
     } else {
-      assertBounds(13, TimestampType.withoutZone(), -1_900_300L, -7_000L, metricsWithStats);
+      assertBounds(13, TimestampType.withoutZone(), -1_900_300L, -7_000L, metrics);
     }
   }
 
@@ -281,41 +271,34 @@ public abstract class TestMetrics {
     record.setField("decimalAsFixed", new BigDecimal("5.80"));
 
     Metrics metrics = getMetrics(schema, record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1);
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(
-        1, DecimalType.of(4, 2), new BigDecimal("2.55"), new BigDecimal("2.55"), metricsWithStats);
-    assertCounts(2, 1L, 0L, metricsWithStats);
-    assertBounds(
-        2, DecimalType.of(14, 2), new BigDecimal("4.75"), new BigDecimal("4.75"), metricsWithStats);
-    assertCounts(3, 1L, 0L, metricsWithStats);
-    assertBounds(
-        3, DecimalType.of(22, 2), new BigDecimal("5.80"), new BigDecimal("5.80"), metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, DecimalType.of(4, 2), new BigDecimal("2.55"), new BigDecimal("2.55"), metrics);
+    assertCounts(2, 1L, 0L, metrics);
+    assertBounds(2, DecimalType.of(14, 2), new BigDecimal("4.75"), new BigDecimal("4.75"), metrics);
+    assertCounts(3, 1L, 0L, metrics);
+    assertBounds(3, DecimalType.of(22, 2), new BigDecimal("5.80"), new BigDecimal("5.80"), metrics);
   }
 
   @TestTemplate
   public void testMetricsForNestedStructFields() throws IOException {
     Metrics metrics = getMetrics(NESTED_SCHEMA, buildNestedTestRecord());
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(1, IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metricsWithStats);
-    assertCounts(3, 1L, 0L, metricsWithStats);
-    assertBounds(3, LongType.get(), 100L, 100L, metricsWithStats);
-    assertCounts(5, 1L, 0L, metricsWithStats);
-    assertBounds(5, LongType.get(), 20L, 20L, metricsWithStats);
-    assertCounts(6, 1L, 0L, metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metrics);
+    assertCounts(3, 1L, 0L, metrics);
+    assertBounds(3, LongType.get(), 100L, 100L, metrics);
+    assertCounts(5, 1L, 0L, metrics);
+    assertBounds(5, LongType.get(), 20L, 20L, metrics);
+    assertCounts(6, 1L, 0L, metrics);
     assertBounds(
         6,
         BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()),
         ByteBuffer.wrap("A".getBytes()),
-        metricsWithStats);
-    assertCounts(7, 1L, 0L, 1L, metricsWithStats);
-    assertBounds(7, DoubleType.get(), null, null, metricsWithStats);
+        metrics);
+    assertCounts(7, 1L, 0L, 1L, metrics);
+    assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -329,12 +312,10 @@ public abstract class TestMetrics {
     MetricsConfig config = MetricsConfig.from(properties, NESTED_SCHEMA, null);
 
     Metrics metrics = getMetrics(NESTED_SCHEMA, config, buildNestedTestRecord());
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.lowerBounds()).hasSize(1);
     assertThat(metrics.upperBounds()).hasSize(1);
-    assertBounds(3, LongType.get(), 100L, 100L, metricsWithStats);
+    assertBounds(3, LongType.get(), 100L, 100L, metrics);
   }
 
   private Record buildNestedTestRecord() {
@@ -373,18 +354,16 @@ public abstract class TestMetrics {
     record.set(1, map);
 
     Metrics metrics = getMetrics(schema, record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
-    assertCounts(1, null, null, metricsWithStats);
-    assertCounts(2, null, null, metricsWithStats);
-    assertCounts(4, null, null, metricsWithStats);
-    assertCounts(6, null, null, metricsWithStats);
-    assertBounds(1, IntegerType.get(), null, null, metricsWithStats);
-    assertBounds(2, StringType.get(), null, null, metricsWithStats);
-    assertBounds(4, IntegerType.get(), null, null, metricsWithStats);
-    assertBounds(6, StringType.get(), null, null, metricsWithStats);
-    assertBounds(7, structType, null, null, metricsWithStats);
+    assertCounts(1, null, null, metrics);
+    assertCounts(2, null, null, metrics);
+    assertCounts(4, null, null, metrics);
+    assertCounts(6, null, null, metrics);
+    assertBounds(1, IntegerType.get(), null, null, metrics);
+    assertBounds(2, StringType.get(), null, null, metrics);
+    assertBounds(4, IntegerType.get(), null, null, metrics);
+    assertBounds(6, StringType.get(), null, null, metrics);
+    assertBounds(7, structType, null, null, metrics);
   }
 
   @TestTemplate
@@ -396,24 +375,20 @@ public abstract class TestMetrics {
     secondRecord.setField("intCol", null);
 
     Metrics metrics = getMetrics(schema, firstRecord, secondRecord);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
     assertThat(metrics.recordCount()).isEqualTo(2L);
-    assertCounts(1, 2L, 2L, metricsWithStats);
-    assertBounds(1, IntegerType.get(), null, null, metricsWithStats);
+    assertCounts(1, 2L, 2L, metrics);
+    assertBounds(1, IntegerType.get(), null, null, metrics);
   }
 
   @TestTemplate
   public void testMetricsForNaNColumns() throws IOException {
     Metrics metrics = getMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, NAN_ONLY_RECORD, NAN_ONLY_RECORD);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(2L);
-    assertCounts(1, 2L, 0L, 2L, metricsWithStats);
-    assertCounts(2, 2L, 0L, 2L, metricsWithStats);
+    assertCounts(1, 2L, 0L, 2L, metrics);
+    assertCounts(2, 2L, 0L, 2L, metrics);
 
-    assertBounds(1, FloatType.get(), null, null, metricsWithStats);
-    assertBounds(2, DoubleType.get(), null, null, metricsWithStats);
+    assertBounds(1, FloatType.get(), null, null, metrics);
+    assertBounds(2, DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -424,14 +399,12 @@ public abstract class TestMetrics {
             NAN_ONLY_RECORD,
             FLOAT_DOUBLE_RECORD_1,
             FLOAT_DOUBLE_RECORD_2);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(3L);
-    assertCounts(1, 3L, 0L, 1L, metricsWithStats);
-    assertCounts(2, 3L, 0L, 1L, metricsWithStats);
+    assertCounts(1, 3L, 0L, 1L, metrics);
+    assertCounts(2, 3L, 0L, 1L, metrics);
 
-    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metricsWithStats);
-    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metricsWithStats);
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @TestTemplate
@@ -442,14 +415,12 @@ public abstract class TestMetrics {
             FLOAT_DOUBLE_RECORD_1,
             NAN_ONLY_RECORD,
             FLOAT_DOUBLE_RECORD_2);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(3L);
-    assertCounts(1, 3L, 0L, 1L, metricsWithStats);
-    assertCounts(2, 3L, 0L, 1L, metricsWithStats);
+    assertCounts(1, 3L, 0L, 1L, metrics);
+    assertCounts(2, 3L, 0L, 1L, metrics);
 
-    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metricsWithStats);
-    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metricsWithStats);
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @TestTemplate
@@ -460,14 +431,12 @@ public abstract class TestMetrics {
             FLOAT_DOUBLE_RECORD_1,
             FLOAT_DOUBLE_RECORD_2,
             NAN_ONLY_RECORD);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(FLOAT_DOUBLE_ONLY_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(3L);
-    assertCounts(1, 3L, 0L, 1L, metricsWithStats);
-    assertCounts(2, 3L, 0L, 1L, metricsWithStats);
+    assertCounts(1, 3L, 0L, 1L, metrics);
+    assertCounts(2, 3L, 0L, 1L, metrics);
 
-    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metricsWithStats);
-    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metricsWithStats);
+    assertBounds(1, FloatType.get(), 1.2F, 5.6F, metrics);
+    assertBounds(2, DoubleType.get(), 3.4D, 7.8D, metrics);
   }
 
   @TestTemplate
@@ -504,8 +473,6 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetricsForRecordsWithSmallRowGroups(
             SIMPLE_SCHEMA, outputFile, records.toArray(new Record[0]));
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(SIMPLE_SCHEMA, metrics));
     InputFile recordsFile = outputFile.toInputFile();
 
     assertThat(recordsFile).isNotNull();
@@ -513,22 +480,18 @@ public abstract class TestMetrics {
     assertThat(splitCount(recordsFile)).isEqualTo(3);
 
     assertThat(metrics.recordCount()).isEqualTo(201L);
-    assertCounts(1, 201L, 0L, metricsWithStats);
-    assertBounds(1, Types.BooleanType.get(), false, true, metricsWithStats);
-    assertBounds(2, Types.IntegerType.get(), 1, 201, metricsWithStats);
-    assertCounts(3, 201L, 1L, metricsWithStats);
-    assertBounds(3, Types.LongType.get(), 2L, 201L, metricsWithStats);
-    assertCounts(4, 201L, 0L, 0L, metricsWithStats);
-    assertBounds(4, Types.FloatType.get(), 1.0F, 201.0F, metricsWithStats);
-    assertCounts(5, 201L, 1L, 0L, metricsWithStats);
-    assertBounds(5, Types.DoubleType.get(), 2.0D, 201.0D, metricsWithStats);
-    assertCounts(6, 201L, 1L, metricsWithStats);
+    assertCounts(1, 201L, 0L, metrics);
+    assertBounds(1, Types.BooleanType.get(), false, true, metrics);
+    assertBounds(2, Types.IntegerType.get(), 1, 201, metrics);
+    assertCounts(3, 201L, 1L, metrics);
+    assertBounds(3, Types.LongType.get(), 2L, 201L, metrics);
+    assertCounts(4, 201L, 0L, 0L, metrics);
+    assertBounds(4, Types.FloatType.get(), 1.0F, 201.0F, metrics);
+    assertCounts(5, 201L, 1L, 0L, metrics);
+    assertBounds(5, Types.DoubleType.get(), 2.0D, 201.0D, metrics);
+    assertCounts(6, 201L, 1L, metrics);
     assertBounds(
-        6,
-        Types.DecimalType.of(10, 2),
-        new BigDecimal("2.00"),
-        new BigDecimal("201.00"),
-        metricsWithStats);
+        6, Types.DecimalType.of(10, 2), new BigDecimal("2.00"), new BigDecimal("201.00"), metrics);
   }
 
   @TestTemplate
@@ -559,8 +522,6 @@ public abstract class TestMetrics {
     Metrics metrics =
         getMetricsForRecordsWithSmallRowGroups(
             NESTED_SCHEMA, outputFile, records.toArray(new Record[0]));
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     InputFile recordsFile = outputFile.toInputFile();
 
     assertThat(recordsFile).isNotNull();
@@ -568,21 +529,21 @@ public abstract class TestMetrics {
     assertThat(splitCount(recordsFile)).isEqualTo(3);
 
     assertThat(metrics.recordCount()).isEqualTo(201L);
-    assertCounts(1, 201L, 0L, metricsWithStats);
-    assertBounds(1, IntegerType.get(), 1, 201, metricsWithStats);
-    assertCounts(3, 201L, 0L, metricsWithStats);
-    assertBounds(3, LongType.get(), 1L, 201L, metricsWithStats);
-    assertCounts(5, 201L, 0L, metricsWithStats);
-    assertBounds(5, LongType.get(), 1L, 201L, metricsWithStats);
-    assertCounts(6, 201L, 0L, metricsWithStats);
+    assertCounts(1, 201L, 0L, metrics);
+    assertBounds(1, IntegerType.get(), 1, 201, metrics);
+    assertCounts(3, 201L, 0L, metrics);
+    assertBounds(3, LongType.get(), 1L, 201L, metrics);
+    assertCounts(5, 201L, 0L, metrics);
+    assertBounds(5, LongType.get(), 1L, 201L, metrics);
+    assertCounts(6, 201L, 0L, metrics);
     assertBounds(
         6,
         BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()),
         ByteBuffer.wrap("A".getBytes()),
-        metricsWithStats);
-    assertCounts(7, 201L, 0L, 201L, metricsWithStats);
-    assertBounds(7, DoubleType.get(), null, null, metricsWithStats);
+        metrics);
+    assertCounts(7, 201L, 0L, 201L, metrics);
+    assertBounds(7, DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -593,20 +554,18 @@ public abstract class TestMetrics {
             MetricsConfig.from(
                 ImmutableMap.of("write.metadata.metrics.default", "none"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).isEmpty();
-    assertCounts(1, null, null, metricsWithStats);
-    assertBounds(1, Types.IntegerType.get(), null, null, metricsWithStats);
-    assertCounts(3, null, null, metricsWithStats);
-    assertBounds(3, Types.LongType.get(), null, null, metricsWithStats);
-    assertCounts(5, null, null, metricsWithStats);
-    assertBounds(5, Types.LongType.get(), null, null, metricsWithStats);
-    assertCounts(6, null, null, metricsWithStats);
-    assertBounds(6, Types.BinaryType.get(), null, null, metricsWithStats);
-    assertCounts(7, null, null, metricsWithStats);
-    assertBounds(7, Types.DoubleType.get(), null, null, metricsWithStats);
+    assertCounts(1, null, null, metrics);
+    assertBounds(1, Types.IntegerType.get(), null, null, metrics);
+    assertCounts(3, null, null, metrics);
+    assertBounds(3, Types.LongType.get(), null, null, metrics);
+    assertCounts(5, null, null, metrics);
+    assertBounds(5, Types.LongType.get(), null, null, metrics);
+    assertCounts(6, null, null, metrics);
+    assertBounds(6, Types.BinaryType.get(), null, null, metrics);
+    assertCounts(7, null, null, metrics);
+    assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -617,21 +576,19 @@ public abstract class TestMetrics {
             MetricsConfig.from(
                 ImmutableMap.of("write.metadata.metrics.default", "counts"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertThat(metrics.columnSizes()).isNotEmpty();
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(1, Types.IntegerType.get(), null, null, metricsWithStats);
-    assertCounts(3, 1L, 0L, metricsWithStats);
-    assertBounds(3, Types.LongType.get(), null, null, metricsWithStats);
-    assertCounts(5, 1L, 0L, metricsWithStats);
-    assertBounds(5, Types.LongType.get(), null, null, metricsWithStats);
-    assertCounts(6, 1L, 0L, metricsWithStats);
-    assertBounds(6, Types.BinaryType.get(), null, null, metricsWithStats);
-    assertCounts(7, 1L, 0L, 1L, metricsWithStats);
-    assertBounds(7, Types.DoubleType.get(), null, null, metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, Types.IntegerType.get(), null, null, metrics);
+    assertCounts(3, 1L, 0L, metrics);
+    assertBounds(3, Types.LongType.get(), null, null, metrics);
+    assertCounts(5, 1L, 0L, metrics);
+    assertBounds(5, Types.LongType.get(), null, null, metrics);
+    assertCounts(6, 1L, 0L, metrics);
+    assertBounds(6, Types.BinaryType.get(), null, null, metrics);
+    assertCounts(7, 1L, 0L, 1L, metrics);
+    assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -642,27 +599,24 @@ public abstract class TestMetrics {
             MetricsConfig.from(
                 ImmutableMap.of("write.metadata.metrics.default", "full"), NESTED_SCHEMA, null),
             buildNestedTestRecord());
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertThat(metrics.columnSizes()).isNotEmpty();
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(
-        1, Types.IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metricsWithStats);
-    assertCounts(3, 1L, 0L, metricsWithStats);
-    assertBounds(3, Types.LongType.get(), 100L, 100L, metricsWithStats);
-    assertCounts(5, 1L, 0L, metricsWithStats);
-    assertBounds(5, Types.LongType.get(), 20L, 20L, metricsWithStats);
-    assertCounts(6, 1L, 0L, metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, Types.IntegerType.get(), Integer.MAX_VALUE, Integer.MAX_VALUE, metrics);
+    assertCounts(3, 1L, 0L, metrics);
+    assertBounds(3, Types.LongType.get(), 100L, 100L, metrics);
+    assertCounts(5, 1L, 0L, metrics);
+    assertBounds(5, Types.LongType.get(), 20L, 20L, metrics);
+    assertCounts(6, 1L, 0L, metrics);
     assertBounds(
         6,
         Types.BinaryType.get(),
         ByteBuffer.wrap("A".getBytes()),
         ByteBuffer.wrap("A".getBytes()),
-        metricsWithStats);
-    assertCounts(7, 1L, 0L, 1L, metricsWithStats);
-    assertBounds(7, Types.DoubleType.get(), null, null, metricsWithStats);
+        metrics);
+    assertCounts(7, 1L, 0L, 1L, metrics);
+    assertBounds(7, Types.DoubleType.get(), null, null, metrics);
   }
 
   @TestTemplate
@@ -682,16 +636,14 @@ public abstract class TestMetrics {
                 singleStringColSchema,
                 null),
             record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(singleStringColSchema, metrics));
 
     CharBuffer expectedMinBound = CharBuffer.wrap("Lorem ipsu");
     CharBuffer expectedMaxBound = CharBuffer.wrap("Lorem ipsv");
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertThat(metrics.columnSizes()).isNotEmpty();
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(1, Types.StringType.get(), expectedMinBound, expectedMaxBound, metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, Types.StringType.get(), expectedMinBound, expectedMaxBound, metrics);
   }
 
   @TestTemplate
@@ -711,16 +663,14 @@ public abstract class TestMetrics {
                 singleBinaryColSchema,
                 null),
             record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(singleBinaryColSchema, metrics));
 
     ByteBuffer expectedMinBounds = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x5});
     ByteBuffer expectedMaxBounds = ByteBuffer.wrap(new byte[] {0x1, 0x2, 0x3, 0x4, 0x6});
     assertThat(metrics.recordCount()).isEqualTo(1L);
     assertThat(metrics.columnSizes()).doesNotContainValue(null);
     assertThat(metrics.columnSizes()).isNotEmpty();
-    assertCounts(1, 1L, 0L, metricsWithStats);
-    assertBounds(1, Types.BinaryType.get(), expectedMinBounds, expectedMaxBounds, metricsWithStats);
+    assertCounts(1, 1L, 0L, metrics);
+    assertBounds(1, Types.BinaryType.get(), expectedMinBounds, expectedMaxBounds, metrics);
   }
 
   @TestTemplate
@@ -772,22 +722,15 @@ public abstract class TestMetrics {
 
     Metrics metrics =
         getMetrics(SIMPLE_SCHEMA, MetricsConfig.forTable(table), firstRecord, secondRecord);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(SIMPLE_SCHEMA, metrics));
 
     assertThat(metrics.recordCount()).isEqualTo(2L);
-    assertBounds(1, BooleanType.get(), false, true, metricsWithStats);
-    assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, Integer.MAX_VALUE, metricsWithStats);
-    assertBounds(3, LongType.get(), Long.MIN_VALUE, Long.MAX_VALUE, metricsWithStats);
+    assertBounds(1, BooleanType.get(), false, true, metrics);
+    assertBounds(2, IntegerType.get(), Integer.MIN_VALUE, Integer.MAX_VALUE, metrics);
+    assertBounds(3, LongType.get(), Long.MIN_VALUE, Long.MAX_VALUE, metrics);
     assertBounds(
-        6,
-        DecimalType.of(10, 2),
-        new BigDecimal("0.00"),
-        new BigDecimal("10.00"),
-        metricsWithStats);
-    assertBounds(
-        7, StringType.get(), CharBuffer.wrap("AAA"), CharBuffer.wrap("ZZZ"), metricsWithStats);
-    assertBounds(8, DateType.get(), 1500, 3000, metricsWithStats);
+        6, DecimalType.of(10, 2), new BigDecimal("0.00"), new BigDecimal("10.00"), metrics);
+    assertBounds(7, StringType.get(), CharBuffer.wrap("AAA"), CharBuffer.wrap("ZZZ"), metrics);
+    assertBounds(8, DateType.get(), 1500, 3000, metrics);
   }
 
   @TestTemplate
@@ -813,51 +756,29 @@ public abstract class TestMetrics {
     record.setField("nestedStructCol", nestedStruct);
 
     Metrics metrics = getMetrics(NESTED_SCHEMA, MetricsConfig.forTable(table), record);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(NESTED_SCHEMA, metrics));
 
-    assertBounds(3, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metricsWithStats);
-    assertBounds(5, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metricsWithStats);
+    assertBounds(3, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metrics);
+    assertBounds(5, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metrics);
+  }
+
+  protected void assertCounts(int fieldId, Long valueCount, Long nullValueCount, Metrics metrics) {
+    assertCounts(fieldId, valueCount, nullValueCount, null, metrics);
   }
 
   protected void assertCounts(
-      int fieldId, Long valueCount, Long nullValueCount, MetricsWithStats metricsWithStats) {
-    assertCounts(fieldId, valueCount, nullValueCount, null, metricsWithStats);
+      int fieldId, Long valueCount, Long nullValueCount, Long nanValueCount, Metrics metrics) {
+    assertThat(metrics.valueCounts().get(fieldId)).isEqualTo(valueCount);
+    assertThat(metrics.nullValueCounts().get(fieldId)).isEqualTo(nullValueCount);
+    assertThat(metrics.nanValueCounts().get(fieldId)).isEqualTo(nanValueCount);
   }
 
-  protected void assertCounts(
-      int fieldId,
-      Long valueCount,
-      Long nullValueCount,
-      Long nanValueCount,
-      MetricsWithStats metricsWithStats) {
-    assertThat(metricsWithStats.metrics().valueCounts().get(fieldId)).isEqualTo(valueCount);
-    assertThat(metricsWithStats.metrics().nullValueCounts().get(fieldId)).isEqualTo(nullValueCount);
-    assertThat(metricsWithStats.metrics().nanValueCounts().get(fieldId)).isEqualTo(nanValueCount);
-    if (null != metricsWithStats.stats()) {
-      assertSerializable(metricsWithStats.stats());
-      FieldStats<?> stat = metricsWithStats.stats().statsFor(fieldId);
-      if (null == stat) {
-        // stat is only null when metrics mode is set to none
-        assertThat(valueCount).isNull();
-        assertThat(nullValueCount).isNull();
-        assertThat(nanValueCount).isNull();
-      } else {
-        assertThat(stat.valueCount()).isEqualTo(valueCount);
-        assertThat(stat.nullValueCount()).isEqualTo(nullValueCount);
-        assertThat(stat.nanValueCount()).isEqualTo(nanValueCount);
-      }
-    }
-  }
-
-  @SuppressWarnings("DataFlowIssue")
   protected <T> void assertBounds(
-      int fieldId, Type type, T lowerBound, T upperBound, MetricsWithStats metricsWithStats) {
-    Map<Integer, ByteBuffer> lowerBounds = metricsWithStats.metrics().lowerBounds();
-    Map<Integer, ByteBuffer> upperBounds = metricsWithStats.metrics().upperBounds();
+      int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
+    Map<Integer, ByteBuffer> lowerBounds = metrics.lowerBounds();
+    Map<Integer, ByteBuffer> upperBounds = metrics.upperBounds();
     if (null != lowerBound || null != upperBound) {
       // if there's an expected lower/upper bound, then the original type should be available
-      assertThat(metricsWithStats.metrics().originalTypes().get(fieldId)).isEqualTo(type);
+      assertThat(metrics.originalTypes().get(fieldId)).isEqualTo(type);
     }
 
     if (lowerBounds.containsKey(fieldId)) {
@@ -870,37 +791,6 @@ public abstract class TestMetrics {
       assertThat((Object) fromByteBuffer(type, upperBounds.get(fieldId))).isEqualTo(upperBound);
     } else {
       assertThat(upperBound).isNull();
-    }
-
-    if (null != metricsWithStats.stats()) {
-      assertSerializable(metricsWithStats.stats());
-      FieldStats<?> stat = metricsWithStats.stats().statsFor(fieldId);
-      if (null == stat) {
-        // stat is only null when metrics mode is set to none
-        assertThat(lowerBound).isNull();
-        assertThat(upperBound).isNull();
-      } else {
-        assertThat(stat).isNotNull();
-        if (lowerBound instanceof CharBuffer || upperBound instanceof CharBuffer) {
-          // CharBuffer is stored as String in content stats
-          assertThat(stat.lowerBound()).isEqualTo(lowerBound.toString());
-          assertThat(stat.upperBound()).isEqualTo(upperBound.toString());
-        } else {
-          assertThat(stat.lowerBound()).isEqualTo(lowerBound);
-          assertThat(stat.upperBound()).isEqualTo(upperBound);
-        }
-      }
-    }
-  }
-
-  protected record MetricsWithStats(Metrics metrics, ContentStats stats) {}
-
-  private void assertSerializable(ContentStats stats) {
-    try {
-      ContentStats serialized = TestHelpers.roundTripSerialize(stats);
-      assertThat(serialized).isEqualTo(stats);
-    } catch (IOException | ClassNotFoundException e) {
-      throw new RuntimeException(e);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -255,6 +256,39 @@ public abstract class TestMetrics {
     } else {
       assertBounds(13, TimestampType.withoutZone(), -1_900_300L, -7_000L, metrics);
     }
+  }
+
+  @TestTemplate
+  public void testMetricsForGeospatialTypes() throws IOException {
+    // Geometry and geography are only written by the Parquet path; other formats do not support
+    // the geo types yet.
+    assumeThat(fileFormat()).isEqualTo(FileFormat.PARQUET);
+
+    Schema schema =
+        new Schema(
+            required(1, "id", LongType.get()),
+            optional(2, "geom", Types.GeometryType.crs84()),
+            optional(3, "geog", Types.GeographyType.crs84()));
+
+    Record first = GenericRecord.create(schema);
+    first.setField("id", 1L);
+    first.setField("geom", wkbPoint(30, 10));
+    first.setField("geog", wkbPoint(-5, 40));
+    Record second = GenericRecord.create(schema);
+    second.setField("id", 2L);
+    // both geo columns are left null
+
+    Metrics metrics = getMetrics(schema, first, second);
+    MetricsWithStats metricsWithStats =
+        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
+    assertThat(metrics.recordCount()).isEqualTo(2L);
+
+    // geometry and geography keep value/null counts but no bounds: lexicographic WKB min/max is not
+    // meaningful, so bounds are intentionally skipped (spatial bounds are a separate follow-up).
+    assertCounts(2, 2L, 1L, metricsWithStats);
+    assertBounds(2, Types.GeometryType.crs84(), null, null, metricsWithStats);
+    assertCounts(3, 2L, 1L, metricsWithStats);
+    assertBounds(3, Types.GeographyType.crs84(), null, null, metricsWithStats);
   }
 
   @TestTemplate
@@ -763,6 +797,18 @@ public abstract class TestMetrics {
 
   protected void assertCounts(int fieldId, Long valueCount, Long nullValueCount, Metrics metrics) {
     assertCounts(fieldId, valueCount, nullValueCount, null, metrics);
+  }
+
+  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
+    // little-endian WKB encoding of a point
+    return ByteBuffer.wrap(
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1) // byte order: little endian
+            .putInt(1) // WKB geometry type: Point
+            .putDouble(xCoord)
+            .putDouble(yCoord)
+            .array());
   }
 
   protected void assertCounts(

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -256,39 +255,6 @@ public abstract class TestMetrics {
     } else {
       assertBounds(13, TimestampType.withoutZone(), -1_900_300L, -7_000L, metrics);
     }
-  }
-
-  @TestTemplate
-  public void testMetricsForGeospatialTypes() throws IOException {
-    // Geometry and geography are only written by the Parquet path; other formats do not support
-    // the geo types yet.
-    assumeThat(fileFormat()).isEqualTo(FileFormat.PARQUET);
-
-    Schema schema =
-        new Schema(
-            required(1, "id", LongType.get()),
-            optional(2, "geom", Types.GeometryType.crs84()),
-            optional(3, "geog", Types.GeographyType.crs84()));
-
-    Record first = GenericRecord.create(schema);
-    first.setField("id", 1L);
-    first.setField("geom", wkbPoint(30, 10));
-    first.setField("geog", wkbPoint(-5, 40));
-    Record second = GenericRecord.create(schema);
-    second.setField("id", 2L);
-    // both geo columns are left null
-
-    Metrics metrics = getMetrics(schema, first, second);
-    MetricsWithStats metricsWithStats =
-        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
-    assertThat(metrics.recordCount()).isEqualTo(2L);
-
-    // geometry and geography keep value/null counts but no bounds: lexicographic WKB min/max is not
-    // meaningful, so bounds are intentionally skipped (spatial bounds are a separate follow-up).
-    assertCounts(2, 2L, 1L, metricsWithStats);
-    assertBounds(2, Types.GeometryType.crs84(), null, null, metricsWithStats);
-    assertCounts(3, 2L, 1L, metricsWithStats);
-    assertBounds(3, Types.GeographyType.crs84(), null, null, metricsWithStats);
   }
 
   @TestTemplate
@@ -797,18 +763,6 @@ public abstract class TestMetrics {
 
   protected void assertCounts(int fieldId, Long valueCount, Long nullValueCount, Metrics metrics) {
     assertCounts(fieldId, valueCount, nullValueCount, null, metrics);
-  }
-
-  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
-    // little-endian WKB encoding of a point
-    return ByteBuffer.wrap(
-        ByteBuffer.allocate(21)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .put((byte) 1) // byte order: little endian
-            .putInt(1) // WKB geometry type: Point
-            .putDouble(xCoord)
-            .putDouble(yCoord)
-            .array());
   }
 
   protected void assertCounts(

--- a/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsConfig.java
@@ -22,7 +22,9 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
 import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -111,5 +113,96 @@ public class TestMetricsConfig {
     assertThat(MetricsConfig.limitFieldIds(schema, 2)).isEqualTo(Set.of(5, 3));
     assertThat(MetricsConfig.limitFieldIds(schema, 3)).isEqualTo(Set.of(5, 3, 4));
     assertThat(MetricsConfig.limitFieldIds(schema, 4)).isEqualTo(Set.of(5, 3, 4));
+  }
+
+  @Test
+  public void testColumnModeAndFieldIdsFromColumnConfig() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "category", Types.StringType.get()));
+
+    Map<String, String> props =
+        ImmutableMap.of(
+            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "id", "full",
+            TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "data", "none");
+
+    MetricsConfig config = MetricsConfig.from(props, schema, null);
+
+    assertThat(config.metricsFieldIds())
+        .as("Should track field ids for configured and defaulted columns")
+        .containsExactlyInAnyOrder(1, 2, 3);
+
+    assertThat(config.columnMode(1))
+        .as("Should return the configured mode for a tracked field id")
+        .isEqualTo(MetricsModes.Full.get());
+    assertThat(config.columnMode(2)).isEqualTo(MetricsModes.None.get());
+    assertThat(config.columnMode(3))
+        .as("Defaulted column should use the default mode")
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+  }
+
+  @Test
+  public void testAllDefaultedColumnsTracked() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(3, "category", Types.StringType.get()));
+
+    MetricsConfig config = MetricsConfig.from(ImmutableMap.of(), schema, null);
+
+    assertThat(config.metricsFieldIds())
+        .as("Should track field ids for all columns that use the default mode")
+        .containsExactlyInAnyOrder(1, 2, 3);
+
+    assertThat(config.columnMode(1)).isEqualTo(MetricsModes.Truncate.withLength(16));
+    assertThat(config.columnMode(2)).isEqualTo(MetricsModes.Truncate.withLength(16));
+    assertThat(config.columnMode(3)).isEqualTo(MetricsModes.Truncate.withLength(16));
+  }
+
+  @Test
+  public void testLimitingMetricsFieldIds() {
+    Schema schema =
+        new Schema(
+            required(1, "a", Types.IntegerType.get()),
+            required(2, "b", Types.IntegerType.get()),
+            required(3, "c", Types.IntegerType.get()),
+            required(4, "d", Types.IntegerType.get()),
+            required(5, "e", Types.IntegerType.get()));
+
+    Map<String, String> limitedToTwo =
+        ImmutableMap.of(TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS, "2");
+    MetricsConfig config = MetricsConfig.from(limitedToTwo, schema, null);
+
+    // only the fields within the inferred limit are tracked, matching limitFieldIds
+    assertThat(config.metricsFieldIds())
+        .as("Should track only the field ids within the inferred column limit")
+        .containsExactlyInAnyOrderElementsOf(MetricsConfig.limitFieldIds(schema, 2))
+        .containsExactlyInAnyOrder(1, 2);
+
+    // tracked fields keep metrics at the default mode
+    assertThat(config.columnMode(1)).isEqualTo(MetricsModes.Truncate.withLength(16));
+    assertThat(config.columnMode(2)).isEqualTo(MetricsModes.Truncate.withLength(16));
+    // fields past the limit are dropped from both id tracking and metrics
+    assertThat(config.columnMode(3))
+        .as("Field past the limit should not have metrics")
+        .isEqualTo(MetricsModes.None.get());
+    assertThat(config.columnMode(4)).isEqualTo(MetricsModes.None.get());
+    assertThat(config.columnMode(5)).isEqualTo(MetricsModes.None.get());
+
+    // raising the limit expands both the tracked ids and the columns with metrics
+    Map<String, String> limitedToThree =
+        ImmutableMap.of(TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS, "3");
+    MetricsConfig wider = MetricsConfig.from(limitedToThree, schema, null);
+
+    assertThat(wider.metricsFieldIds())
+        .as("Raising the limit should track more field ids")
+        .containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(wider.columnMode(3))
+        .as("Raising the limit should give the field metrics at the default mode")
+        .isEqualTo(MetricsModes.Truncate.withLength(16));
+    assertThat(wider.columnMode(4)).isEqualTo(MetricsModes.None.get());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -87,7 +87,7 @@ public class TestMetricsModes {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col",
             "troncate(5)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(properties);
+    MetricsConfig config = MetricsConfig.from(properties, null, null);
     assertThat(config.columnMode("col"))
         .as("Invalid mode should be defaulted to table default (full)")
         .isEqualTo(MetricsModes.Full.get());
@@ -102,7 +102,7 @@ public class TestMetricsModes {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col",
             "troncate(5)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(properties);
+    MetricsConfig config = MetricsConfig.from(properties, null, null);
     assertThat(config.columnMode("col"))
         .as("Invalid mode should be defaulted to library default (truncate(16))")
         .isEqualTo(MetricsModes.Truncate.withLength(16));

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
@@ -109,11 +109,11 @@ public class TestTrackedFile {
   }
 
   @Test
-  public void schemaWithContentStatsPartitionIsRequired() {
+  public void schemaWithContentStatsPartitionIsOptional() {
     Types.StructType type = TrackedFile.schemaWithContentStats(PARTITION_TYPE, CONTENT_STATS_TYPE);
     Types.NestedField partitionField = type.field(TrackedFile.PARTITION_ID);
 
-    assertThat(partitionField.isRequired()).isTrue();
+    assertThat(partitionField.isOptional()).isTrue();
     assertThat(partitionField.name()).isEqualTo(TrackedFile.PARTITION_NAME);
     assertThat(partitionField.doc()).isEqualTo(TrackedFile.PARTITION_DOC);
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -311,7 +311,7 @@ class TestTrackedFileAdapters {
     DataFile dataFile = TrackedFileAdapters.asDataFile(file, UNPARTITIONED);
 
     assertThat(dataFile.specId()).isEqualTo(UNPARTITIONED_SPEC_ID);
-    assertThat(dataFile.partition().size()).isEqualTo(0);
+    assertThat(dataFile.partition()).isEqualTo(PartitionData.EMPTY);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -20,14 +20,16 @@ package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestTrackedFileStruct {
   private static final int FORMAT_VERSION_V4 = 4;
@@ -36,245 +38,221 @@ class TestTrackedFileStruct {
           Types.NestedField.optional(1000, "id_bucket", Types.IntegerType.get()),
           Types.NestedField.optional(1001, "category", Types.StringType.get()));
 
-  // Ordinals looked up from the TrackedFile schema so tests don't hard-code positions.
-  private static final List<Types.NestedField> SCHEMA_FIELDS =
-      TrackedFile.schemaWithContentStats(Types.StructType.of(), Types.StructType.of()).fields();
-  private static final int TRACKING_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.TRACKING);
-  private static final int CONTENT_TYPE_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.CONTENT_TYPE);
-  private static final int FORMAT_VERSION_ORDINAL =
-      SCHEMA_FIELDS.indexOf(TrackedFile.FORMAT_VERSION);
-  private static final int LOCATION_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.LOCATION);
-  private static final int FILE_FORMAT_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.FILE_FORMAT);
-  private static final int RECORD_COUNT_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.RECORD_COUNT);
-  private static final int FILE_SIZE_IN_BYTES_ORDINAL =
-      SCHEMA_FIELDS.indexOf(TrackedFile.FILE_SIZE_IN_BYTES);
-  private static final int SPEC_ID_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.SPEC_ID);
-  private static final int PARTITION_ORDINAL = ordinalOf(TrackedFile.PARTITION_ID);
-  private static final int SORT_ORDER_ID_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.SORT_ORDER_ID);
-  private static final int DELETION_VECTOR_ORDINAL =
-      SCHEMA_FIELDS.indexOf(TrackedFile.DELETION_VECTOR);
-  private static final int MANIFEST_INFO_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.MANIFEST_INFO);
-  private static final int KEY_METADATA_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.KEY_METADATA);
-  private static final int SPLIT_OFFSETS_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.SPLIT_OFFSETS);
-  private static final int EQUALITY_IDS_ORDINAL = SCHEMA_FIELDS.indexOf(TrackedFile.EQUALITY_IDS);
+  private static final List<Types.NestedField> FIELDS =
+      TrackedFile.schemaWithContentStats(PARTITION_TYPE, Types.StructType.of()).fields();
 
-  // Ordinal of MetadataColumns.ROW_POSITION within TrackingStruct's BASE_TYPE,
-  // which appends ROW_POSITION after the Tracking schema fields.
-  private static final int MANIFEST_POS_ORDINAL = Tracking.schema().fields().size();
+  private static final Comparator<StructLike> PARTITION_COMPARATOR =
+      Comparators.forType(PARTITION_TYPE);
+  private static final Comparator<StructLike> TRACKING_COMPARATOR =
+      Comparators.forType(Tracking.schema());
 
-  private static int ordinalOf(int fieldId) {
-    for (int i = 0; i < SCHEMA_FIELDS.size(); i++) {
-      if (SCHEMA_FIELDS.get(i).fieldId() == fieldId) {
-        return i;
-      }
-    }
-    throw new IllegalArgumentException("Field not found in TrackedFile schema: " + fieldId);
-  }
+  private static final Tracking TRACKING =
+      new TrackingStruct(EntryStatus.ADDED, 42L, 10L, 10L, 43L, 1000L, null, null);
+
+  private static final PartitionData PARTITION = newPartition(7, "music");
+
+  private static final DeletionVectorStruct DELETION_VECTOR =
+      DeletionVectorStruct.builder()
+          .location("s3://bucket/dv.puffin")
+          .offset(100L)
+          .sizeInBytes(50L)
+          .cardinality(5L)
+          .build();
+
+  private static final ManifestInfoStruct MANIFEST_INFO =
+      ManifestInfoStruct.builder()
+          .addedFilesCount(10)
+          .existingFilesCount(20)
+          .deletedFilesCount(3)
+          .replacedFilesCount(2)
+          .addedRowsCount(1000L)
+          .existingRowsCount(2000L)
+          .deletedRowsCount(300L)
+          .replacedRowsCount(200L)
+          .minSequenceNumber(5L)
+          .build();
+
+  private static final ContentStats CONTENT_STATS =
+      BaseContentStats.builder()
+          .withTableSchema(
+              new Schema(
+                  Types.NestedField.optional(1, "id", Types.IntegerType.get()),
+                  Types.NestedField.optional(2, "data", Types.FloatType.get())))
+          .withFieldStats(BaseFieldStats.builder().fieldId(1).build())
+          .withFieldStats(BaseFieldStats.builder().fieldId(2).build())
+          .build();
 
   @Test
-  void testFieldAccess() {
-    TrackedFileStruct file = new TrackedFileStruct();
-    Tracking tracking = TrackingBuilder.added(42L).build();
-    DeletionVectorStruct dv =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/dv.puffin")
-            .offset(100L)
-            .sizeInBytes(50L)
-            .cardinality(5L)
-            .build();
-    ManifestInfoStruct info =
-        ManifestInfoStruct.builder()
-            .addedFilesCount(10)
-            .existingFilesCount(20)
-            .deletedFilesCount(3)
-            .replacedFilesCount(2)
-            .addedRowsCount(1000L)
-            .existingRowsCount(2000L)
-            .deletedRowsCount(300L)
-            .replacedRowsCount(200L)
-            .minSequenceNumber(5L)
-            .build();
+  void fieldAccess() {
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            TRACKING,
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            "s3://bucket/data/00000-0-file.parquet",
+            FileFormat.PARQUET,
+            PARTITION,
+            50L,
+            512L,
+            1,
+            CONTENT_STATS,
+            5,
+            DELETION_VECTOR,
+            MANIFEST_INFO,
+            ByteBuffer.wrap(new byte[] {1, 2, 3}),
+            ImmutableList.of(100L, 200L),
+            ImmutableList.of(1, 2, 3));
 
-    file.set(TRACKING_ORDINAL, tracking);
-    file.set(CONTENT_TYPE_ORDINAL, FileContent.EQUALITY_DELETES.id());
-    file.set(FORMAT_VERSION_ORDINAL, FORMAT_VERSION_V4);
-    file.set(LOCATION_ORDINAL, "s3://bucket/data/eq-delete.avro");
-    file.set(FILE_FORMAT_ORDINAL, "avro");
-    file.set(RECORD_COUNT_ORDINAL, 50L);
-    file.set(FILE_SIZE_IN_BYTES_ORDINAL, 512L);
-    file.set(SPEC_ID_ORDINAL, 1);
-    file.set(SORT_ORDER_ID_ORDINAL, 5);
-    file.set(DELETION_VECTOR_ORDINAL, dv);
-    file.set(MANIFEST_INFO_ORDINAL, info);
-    file.set(KEY_METADATA_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2, 3}));
-    file.set(SPLIT_OFFSETS_ORDINAL, ImmutableList.of(100L, 200L));
-    file.set(EQUALITY_IDS_ORDINAL, ImmutableList.of(1, 2, 3));
-
-    assertThat(file.tracking()).isNotNull();
-    assertThat(file.tracking().status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(file.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(file.contentType()).isEqualTo(FileContent.EQUALITY_DELETES);
+    assertThat(file.tracking()).isSameAs(TRACKING);
+    assertThat(file.contentType()).isEqualTo(FileContent.DATA);
     assertThat(file.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
-    assertThat(file.location()).isEqualTo("s3://bucket/data/eq-delete.avro");
-    assertThat(file.fileFormat()).isEqualTo(FileFormat.AVRO);
+    assertThat(file.location()).isEqualTo("s3://bucket/data/00000-0-file.parquet");
+    assertThat(file.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(file.partition()).isSameAs(PARTITION);
     assertThat(file.recordCount()).isEqualTo(50L);
     assertThat(file.fileSizeInBytes()).isEqualTo(512L);
     assertThat(file.specId()).isEqualTo(1);
+    assertThat(file.contentStats()).isSameAs(CONTENT_STATS);
     assertThat(file.sortOrderId()).isEqualTo(5);
-    assertThat(file.deletionVector()).isSameAs(dv);
-    assertThat(file.manifestInfo()).isSameAs(info);
+    assertThat(file.deletionVector()).isSameAs(DELETION_VECTOR);
+    assertThat(file.manifestInfo()).isSameAs(MANIFEST_INFO);
     assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(file.splitOffsets()).containsExactly(100L, 200L);
     assertThat(file.equalityIds()).containsExactly(1, 2, 3);
-    // should return EMPTY_PARTITION_DATA
-    assertThat(file.partition()).isNotNull();
-    assertThat(file.partition().size()).isEqualTo(0);
   }
 
   @Test
-  void testReaderSideFields() {
+  void setByPosition() {
     TrackedFileStruct file = new TrackedFileStruct();
+    file.set(pos("tracking"), TRACKING);
+    file.set(pos("content_type"), FileContent.DATA.id());
+    file.set(pos("format_version"), FORMAT_VERSION_V4);
+    file.set(pos("location"), "s3://bucket/data/00000-0-file.parquet");
+    file.set(pos("file_format"), "parquet");
+    file.set(pos("record_count"), 50L);
+    file.set(pos("file_size_in_bytes"), 512L);
+    file.set(pos("spec_id"), 1);
+    file.set(pos("partition"), PARTITION);
+    file.set(pos("content_stats"), CONTENT_STATS);
+    file.set(pos("sort_order_id"), 5);
+    file.set(pos("deletion_vector"), DELETION_VECTOR);
+    file.set(pos("manifest_info"), MANIFEST_INFO);
+    file.set(pos("key_metadata"), ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    file.set(pos("split_offsets"), ImmutableList.of(100L, 200L));
+    file.set(pos("equality_ids"), ImmutableList.of(1, 2, 3));
 
-    TrackingStruct tracking = new TrackingStruct();
-    tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
-    tracking.set(MANIFEST_POS_ORDINAL, 7L);
-
-    file.set(TRACKING_ORDINAL, tracking);
-    file.set(CONTENT_TYPE_ORDINAL, FileContent.DATA.id());
-    file.set(LOCATION_ORDINAL, "test");
-    file.set(FILE_FORMAT_ORDINAL, "parquet");
-    file.set(RECORD_COUNT_ORDINAL, 0L);
-    file.set(FILE_SIZE_IN_BYTES_ORDINAL, 0L);
-
-    assertThat(file.tracking().manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
-    assertThat(file.tracking().manifestPos()).isEqualTo(7L);
+    assertThat(file.tracking()).isSameAs(TRACKING);
+    assertThat(file.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(file.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
+    assertThat(file.location()).isEqualTo("s3://bucket/data/00000-0-file.parquet");
+    assertThat(file.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(file.recordCount()).isEqualTo(50L);
+    assertThat(file.fileSizeInBytes()).isEqualTo(512L);
+    assertThat(file.specId()).isEqualTo(1);
+    assertThat(file.partition()).isSameAs(PARTITION);
+    assertThat(file.contentStats()).isSameAs(CONTENT_STATS);
+    assertThat(file.sortOrderId()).isEqualTo(5);
+    assertThat(file.deletionVector()).isSameAs(DELETION_VECTOR);
+    assertThat(file.manifestInfo()).isSameAs(MANIFEST_INFO);
+    assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(file.splitOffsets()).containsExactly(100L, 200L);
+    assertThat(file.equalityIds()).containsExactly(1, 2, 3);
   }
 
   @Test
-  void projectionWithoutPartition() {
-    // project only location (field ID 100) and file_size_in_bytes (field ID 104)
-    Types.StructType projection =
-        Types.StructType.of(TrackedFile.LOCATION, TrackedFile.FILE_SIZE_IN_BYTES);
+  void getByPosition() {
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            TRACKING,
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            "s3://bucket/data/00000-0-file.parquet",
+            FileFormat.PARQUET,
+            PARTITION,
+            50L,
+            512L,
+            1,
+            CONTENT_STATS,
+            5,
+            DELETION_VECTOR,
+            MANIFEST_INFO,
+            ByteBuffer.wrap(new byte[] {1, 2, 3}),
+            ImmutableList.of(100L, 200L),
+            ImmutableList.of(1, 2, 3));
 
-    TrackedFileStruct file = new TrackedFileStruct(projection);
-    assertThat(file.size()).isEqualTo(2);
-    // should return EMPTY_PARTITION_DATA
-    assertThat(file.partition()).isNotNull();
-    assertThat(file.partition().size()).isEqualTo(0);
+    assertThat(file.get(pos("tracking"), Tracking.class)).isSameAs(TRACKING);
+    assertThat(file.get(pos("content_type"), Integer.class)).isEqualTo(FileContent.DATA.id());
+    assertThat(file.get(pos("format_version"), Integer.class)).isEqualTo(FORMAT_VERSION_V4);
+    assertThat(file.get(pos("location"), String.class))
+        .isEqualTo("s3://bucket/data/00000-0-file.parquet");
+    assertThat(file.get(pos("file_format"), String.class)).isEqualTo(FileFormat.PARQUET.toString());
+    assertThat(file.get(pos("record_count"), Long.class)).isEqualTo(50L);
+    assertThat(file.get(pos("file_size_in_bytes"), Long.class)).isEqualTo(512L);
+    assertThat(file.get(pos("spec_id"), Integer.class)).isEqualTo(1);
+    assertThat(file.get(pos("partition"), PartitionData.class)).isSameAs(PARTITION);
+    assertThat(file.get(pos("content_stats"), ContentStats.class)).isSameAs(CONTENT_STATS);
+    assertThat(file.get(pos("sort_order_id"), Integer.class)).isEqualTo(5);
+    assertThat(file.get(pos("deletion_vector"), DeletionVector.class)).isSameAs(DELETION_VECTOR);
+    assertThat(file.get(pos("manifest_info"), ManifestInfo.class)).isSameAs(MANIFEST_INFO);
+    assertThat(file.get(pos("key_metadata"), ByteBuffer.class))
+        .isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(file.get(pos("split_offsets"), List.class)).containsExactly(100L, 200L);
+    assertThat(file.get(pos("equality_ids"), List.class)).containsExactly(1, 2, 3);
   }
 
   @Test
-  void partitionAccess() {
-    PartitionData partition = newPartition(5, "books");
-
-    TrackedFileStruct file = new TrackedFileStruct();
-    file.set(PARTITION_ORDINAL, partition);
-
-    assertThat(file.partition()).isSameAs(partition);
-    assertThat(file.partition().get(0, Integer.class)).isEqualTo(5);
-    assertThat(file.partition().get(1, String.class)).isEqualTo("books");
-  }
-
-  @Test
-  void partitionIsCopied() {
-    PartitionData partition = newPartition(5, "books");
-    TrackedFileStruct file = createFullTrackedFile();
-    file.set(PARTITION_ORDINAL, partition);
+  void copy() {
+    TrackedFileStruct file =
+        new TrackedFileStruct(
+            TRACKING,
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            "s3://bucket/data/00000-0-file.parquet",
+            FileFormat.PARQUET,
+            PARTITION,
+            50L,
+            512L,
+            1,
+            null,
+            5,
+            DELETION_VECTOR,
+            MANIFEST_INFO,
+            ByteBuffer.wrap(new byte[] {1, 2, 3}),
+            ImmutableList.of(100L, 200L),
+            ImmutableList.of(1, 2, 3));
 
     TrackedFile copy = file.copy();
 
-    assertThat(copy.partition()).isNotNull().isNotSameAs(partition);
-    assertThat(copy.partition()).isEqualTo(partition);
-    assertThat(copy.partition().get(0, Integer.class)).isEqualTo(5);
-    assertThat(copy.partition().get(1, String.class)).isEqualTo("books");
-  }
-
-  @Test
-  void testCopy() {
-    TrackedFileStruct file = createFullTrackedFile();
-
-    TrackedFile copy = file.copy();
     assertThat(copy).isInstanceOf(TrackedFileStruct.class);
-
+    assertThat(TRACKING_COMPARATOR.compare((StructLike) copy.tracking(), (StructLike) TRACKING))
+        .isEqualTo(0);
     assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
-    assertThat(copy.location()).isEqualTo("s3://bucket/data/file.parquet");
-    assertThat(copy.fileFormat()).isEqualTo(FileFormat.PARQUET);
-    assertThat(copy.tracking().status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(copy.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(copy.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(copy.specId()).isEqualTo(0);
-    assertThat(copy.sortOrderId()).isEqualTo(1);
-    assertThat(copy.recordCount()).isEqualTo(100L);
-    assertThat(copy.fileSizeInBytes()).isEqualTo(1024L);
     assertThat(copy.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
-    assertThat(copy.keyMetadata()).isNotNull();
-    assertThat(copy.splitOffsets()).containsExactly(50L);
-    assertThat(copy.equalityIds()).isNull();
-    assertThat(copy.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-    assertThat(copy.tracking().manifestPos()).isEqualTo(3L);
-    assertThat(copy.partition()).isEqualTo(newPartition(7, "music"));
-  }
+    assertThat(copy.location()).isEqualTo("s3://bucket/data/00000-0-file.parquet");
+    assertThat(copy.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(copy.recordCount()).isEqualTo(50L);
+    assertThat(copy.fileSizeInBytes()).isEqualTo(512L);
+    assertThat(copy.specId()).isEqualTo(1);
+    assertThat(copy.sortOrderId()).isEqualTo(5);
+    assertThat(copy.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(copy.manifestInfo().addedFilesCount()).isEqualTo(10);
+    assertThat(copy.manifestInfo().addedRowsCount()).isEqualTo(1000L);
+    assertThat(copy.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
+    assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
 
-  @Test
-  void testCopyWithoutStats() {
-    TrackedFileStruct file = createTrackedFileWithStats();
-    assertThat(file.contentStats()).isNotNull();
+    assertThat(PARTITION_COMPARATOR.compare(copy.partition(), PARTITION)).isEqualTo(0);
 
-    TrackedFile copy = file.copyWithoutStats();
-
-    assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
-    assertThat(copy.location()).isEqualTo("s3://bucket/data/file.parquet");
-    assertThat(copy.contentStats()).isNull();
-  }
-
-  @Test
-  void testCopyWithStatsFilters() {
-    TrackedFileStruct file = createTrackedFileWithStats();
-    Set<Integer> keepFieldIds = ImmutableSet.of(1);
-
-    TrackedFile copy = file.copyWithStats(keepFieldIds);
-
-    assertThat(copy.contentStats()).isNotNull();
-    ContentStats stats = copy.contentStats();
-    assertThat(stats.fieldStats()).hasSize(1);
-    assertThat(stats.fieldStats().get(0).fieldId()).isEqualTo(1);
-  }
-
-  @Test
-  void testCopyIsDeep() {
-    TrackedFileStruct file = createFullTrackedFile();
-
-    TrackedFile copy = file.copy();
-
-    // keyMetadata should be a deep copy
+    // mutable fields are deep-copied, not shared with the original
+    assertThat(copy.tracking()).isNotSameAs(file.tracking());
+    assertThat(copy.partition()).isNotSameAs(file.partition());
+    assertThat(copy.deletionVector()).isNotSameAs(file.deletionVector());
+    assertThat(copy.manifestInfo()).isNotSameAs(file.manifestInfo());
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
   }
 
   @Test
-  void testStructLikeSize() {
-    TrackedFileStruct file = new TrackedFileStruct();
-    assertThat(file.size()).isEqualTo(16);
-  }
-
-  @Test
-  void testStructLikeGetSet() {
-    TrackedFileStruct file = new TrackedFileStruct();
-
-    file.set(CONTENT_TYPE_ORDINAL, FileContent.DATA.id());
-    assertThat(file.get(CONTENT_TYPE_ORDINAL, Integer.class)).isEqualTo(FileContent.DATA.id());
-
-    file.set(LOCATION_ORDINAL, "test-location");
-    assertThat(file.get(LOCATION_ORDINAL, String.class)).isEqualTo("test-location");
-
-    file.set(RECORD_COUNT_ORDINAL, 999L);
-    assertThat(file.get(RECORD_COUNT_ORDINAL, Long.class)).isEqualTo(999L);
-
-    file.set(SORT_ORDER_ID_ORDINAL, 3);
-    assertThat(file.get(SORT_ORDER_ID_ORDINAL, Integer.class)).isEqualTo(3);
-  }
-
-  @Test
-  void testProjectedStructLike() {
+  void projectedStructLike() {
     // project only location (field ID 100) and file_size_in_bytes (field ID 104)
     Types.StructType projection =
         Types.StructType.of(TrackedFile.LOCATION, TrackedFile.FILE_SIZE_IN_BYTES);
@@ -282,8 +260,6 @@ class TestTrackedFileStruct {
     TrackedFileStruct file = new TrackedFileStruct(projection);
     assertThat(file.size()).isEqualTo(2);
 
-    // projected position 0 maps to internal position 2 (location)
-    // projected position 1 maps to internal position 5 (file_size_in_bytes)
     file.set(0, "s3://bucket/file.parquet");
     file.set(1, 1024L);
 
@@ -294,112 +270,54 @@ class TestTrackedFileStruct {
   }
 
   @Test
-  void testContentStatsReturnedWhenPresent() {
-    TrackedFileStruct file = createTrackedFileWithStats();
-    assertThat(file.contentStats()).isNotNull();
-    assertThat(file.contentStats().fieldStats()).hasSize(2);
-  }
-
-  @Test
-  void testContentStatsNullWhenNotSet() {
+  void structLikeSize() {
     TrackedFileStruct file = new TrackedFileStruct();
-    file.set(CONTENT_TYPE_ORDINAL, FileContent.DATA.id());
-    file.set(LOCATION_ORDINAL, "test");
-    file.set(FILE_FORMAT_ORDINAL, "parquet");
-    file.set(RECORD_COUNT_ORDINAL, 0L);
-    file.set(FILE_SIZE_IN_BYTES_ORDINAL, 0L);
-    file.set(SPEC_ID_ORDINAL, 0);
-
-    assertThat(file.contentStats()).isNull();
+    assertThat(file.size()).isEqualTo(FIELDS.size());
   }
 
-  @Test
-  void testAllFileContentTypesSupported() {
-    for (FileContent content : FileContent.values()) {
-      TrackedFileStruct file = new TrackedFileStruct();
-      file.set(CONTENT_TYPE_ORDINAL, content.id());
-      assertThat(file.contentType()).isEqualTo(content);
-    }
-  }
-
-  @Test
-  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    TrackedFileStruct file = createFullTrackedFile();
-
-    TrackedFileStruct deserialized = TestHelpers.roundTripSerialize(file);
-
-    assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
-    assertThat(deserialized.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
-    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
-    assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
-    assertThat(deserialized.recordCount()).isEqualTo(100L);
-    assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
-    assertThat(deserialized.specId()).isEqualTo(0);
-    assertThat(deserialized.sortOrderId()).isEqualTo(1);
-    assertThat(deserialized.tracking().status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(deserialized.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
-    assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-    assertThat(deserialized.partition()).isEqualTo(newPartition(7, "music"));
-  }
-
-  @Test
-  void testKryoSerializationRoundTrip() throws IOException {
-    TrackedFileStruct file = createFullTrackedFile();
-
-    TrackedFileStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(file);
-
-    assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
-    assertThat(deserialized.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
-    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
-    assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
-    assertThat(deserialized.recordCount()).isEqualTo(100L);
-    assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
-    assertThat(deserialized.specId()).isEqualTo(0);
-    assertThat(deserialized.sortOrderId()).isEqualTo(1);
-    assertThat(deserialized.tracking().status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(deserialized.tracking().snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
-    assertThat(deserialized.splitOffsets()).containsExactly(50L);
-    assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
-    assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
-    assertThat(deserialized.partition()).isEqualTo(newPartition(7, "music"));
-  }
-
-  static TrackedFileStruct createFullTrackedFile() {
-    DeletionVectorStruct dv =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/dv.puffin")
-            .offset(100L)
-            .sizeInBytes(50L)
-            .cardinality(5L)
-            .build();
-
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  void serializationRoundTrip(RoundTripSerializer<TrackedFileStruct> serializer) throws Exception {
     TrackedFileStruct file =
-        (TrackedFileStruct)
-            TrackedFileBuilder.data(42L)
-                .formatVersion(FORMAT_VERSION_V4)
-                .location("s3://bucket/data/file.parquet")
-                .fileFormat(FileFormat.PARQUET)
-                .partition(newPartition(7, "music"))
-                .recordCount(100L)
-                .fileSizeInBytes(1024L)
-                .specId(0)
-                .sortOrderId(1)
-                .deletionVector(dv)
-                .keyMetadata(ByteBuffer.wrap(new byte[] {1, 2, 3}))
-                .splitOffsets(ImmutableList.of(50L))
-                .build();
+        new TrackedFileStruct(
+            TRACKING,
+            FileContent.DATA,
+            FORMAT_VERSION_V4,
+            "s3://bucket/data/file.parquet",
+            FileFormat.PARQUET,
+            PARTITION,
+            100L,
+            1024L,
+            7,
+            null,
+            1,
+            DELETION_VECTOR,
+            MANIFEST_INFO,
+            ByteBuffer.wrap(new byte[] {1, 2, 3}),
+            ImmutableList.of(50L),
+            ImmutableList.of(1, 2, 3));
 
-    TrackingStruct tracking = (TrackingStruct) file.tracking();
-    tracking.setManifestLocation("s3://bucket/manifest.avro");
-    tracking.set(MANIFEST_POS_ORDINAL, 3L);
+    TrackedFileStruct deserialized = serializer.apply(file);
 
-    return file;
+    assertThat(
+            TRACKING_COMPARATOR.compare(
+                (StructLike) deserialized.tracking(), (StructLike) TRACKING))
+        .isEqualTo(0);
+    assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
+    assertThat(deserialized.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
+    assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
+    assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
+    assertThat(PARTITION_COMPARATOR.compare(deserialized.partition(), PARTITION)).isEqualTo(0);
+    assertThat(deserialized.recordCount()).isEqualTo(100L);
+    assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
+    assertThat(deserialized.specId()).isEqualTo(7);
+    assertThat(deserialized.sortOrderId()).isEqualTo(1);
+    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
+    assertThat(deserialized.manifestInfo().addedFilesCount()).isEqualTo(10);
+    assertThat(deserialized.manifestInfo().addedRowsCount()).isEqualTo(1000L);
+    assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(deserialized.splitOffsets()).containsExactly(50L);
+    assertThat(deserialized.equalityIds()).containsExactly(1, 2, 3);
   }
 
   private static PartitionData newPartition(int idBucket, String category) {
@@ -409,64 +327,13 @@ class TestTrackedFileStruct {
     return partition;
   }
 
-  static TrackedFileStruct createTrackedFileWithStats() {
-    Types.StructType statsStruct =
-        Types.StructType.of(
-            Types.NestedField.optional(
-                10000,
-                "1",
-                Types.StructType.of(
-                    Types.NestedField.optional(10001, "lower_bound", Types.IntegerType.get()),
-                    Types.NestedField.optional(10002, "upper_bound", Types.IntegerType.get()),
-                    Types.NestedField.optional(10004, "value_count", Types.LongType.get()),
-                    Types.NestedField.optional(10005, "null_value_count", Types.LongType.get()),
-                    Types.NestedField.optional(10006, "nan_value_count", Types.LongType.get()))),
-            Types.NestedField.optional(
-                20000,
-                "2",
-                Types.StructType.of(
-                    Types.NestedField.optional(20001, "lower_bound", Types.FloatType.get()),
-                    Types.NestedField.optional(20002, "upper_bound", Types.FloatType.get()),
-                    Types.NestedField.optional(20004, "value_count", Types.LongType.get()),
-                    Types.NestedField.optional(20005, "null_value_count", Types.LongType.get()),
-                    Types.NestedField.optional(20006, "nan_value_count", Types.LongType.get()))));
+  private static int pos(String fieldName) {
+    for (int i = 0; i < FIELDS.size(); i += 1) {
+      if (FIELDS.get(i).name().equals(fieldName)) {
+        return i;
+      }
+    }
 
-    List<FieldStats<?>> fieldStatsList =
-        ImmutableList.of(
-            BaseFieldStats.<Integer>builder()
-                .fieldId(1)
-                .type(Types.IntegerType.get())
-                .valueCount(100L)
-                .nullValueCount(5L)
-                .lowerBound(1)
-                .upperBound(1000)
-                .build(),
-            BaseFieldStats.<Float>builder()
-                .fieldId(2)
-                .type(Types.FloatType.get())
-                .valueCount(200L)
-                .nullValueCount(10L)
-                .nanValueCount(3L)
-                .lowerBound(1.0f)
-                .upperBound(100.0f)
-                .build());
-
-    BaseContentStats stats =
-        BaseContentStats.builder()
-            .withStatsStruct(statsStruct)
-            .withFieldStats(fieldStatsList)
-            .build();
-
-    return (TrackedFileStruct)
-        TrackedFileBuilder.data(0L)
-            .formatVersion(FORMAT_VERSION_V4)
-            .location("s3://bucket/data/file.parquet")
-            .fileFormat(FileFormat.PARQUET)
-            .partition(new PartitionData(Types.StructType.of()))
-            .recordCount(100L)
-            .fileSizeInBytes(1024L)
-            .specId(0)
-            .contentStats(stats)
-            .build();
+    throw new IllegalArgumentException("No such field in TrackedFile schema: " + fieldName);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestTrackingBuilder {
+
+  @Test
+  void testAddedWithSameCommitDvStaysAdded() {
+    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
+
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(42L);
+    assertThat(tracking.deletedPositions()).isNull();
+    assertThat(tracking.replacedPositions()).isNull();
+    // sequence numbers and firstRowId remain null; populated by inheritance
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
+    assertThat(tracking.firstRowId()).isNull();
+  }
+
+  @Test
+  void testExistingBuilderPreservesSourceFields() {
+    Tracking source = sourceTracking();
+
+    Tracking existing = TrackingBuilder.from(source, 1L).build();
+
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
+    assertThat(existing.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(existing.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(existing.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(existing.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testDeleteUpdatesSnapshotIdAndPreservesRest() {
+    Tracking source = sourceTracking();
+
+    Tracking deleted = TrackingBuilder.deleted(source, 999L);
+
+    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
+    assertThat(deleted.snapshotId()).isEqualTo(999L);
+    assertThat(deleted.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(deleted.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(deleted.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(deleted.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testReplaceUpdatesSnapshotIdAndPreservesRest() {
+    Tracking source = sourceTracking();
+
+    Tracking replaced = TrackingBuilder.replaced(source, 999L);
+
+    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
+    assertThat(replaced.snapshotId()).isEqualTo(999L);
+    assertThat(replaced.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(replaced.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(replaced.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(replaced.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testSourceDvPositionsAreNotCarriedForward() {
+    Tracking source =
+        new TrackingStruct(
+            EntryStatus.ADDED, 42L, 10L, 10L, 43L, 1000L, new byte[] {1, 2}, new byte[] {3, 4});
+
+    Tracking existing = TrackingBuilder.from(source, 1L).build();
+    assertThat(existing.deletedPositions()).isNull();
+    assertThat(existing.replacedPositions()).isNull();
+
+    Tracking deleted = TrackingBuilder.deleted(source, 999L);
+    assertThat(deleted.deletedPositions()).isNull();
+    assertThat(deleted.replacedPositions()).isNull();
+
+    Tracking replaced = TrackingBuilder.replaced(source, 999L);
+    assertThat(replaced.deletedPositions()).isNull();
+    assertThat(replaced.replacedPositions()).isNull();
+  }
+
+  @Test
+  void testDvUpdatedProducesModifiedAndAdvancesDvSnapshotId() {
+    Tracking source = sourceTracking();
+    Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
+
+    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
+    // the entry snapshot id is preserved so we still know when the base file was added
+    assertThat(modified.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
+    // only the DV snapshot id advances to the commit snapshot
+    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
+  }
+
+  @Test
+  void testManifestDVMutatorsRejectedOnAdded() {
+    assertThatThrownBy(
+            () -> TrackingBuilder.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set deleted positions on ADDED entry");
+
+    assertThatThrownBy(
+            () -> TrackingBuilder.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set replaced positions on ADDED entry");
+  }
+
+  @Test
+  void testDvUpdatedRejectedWhenManifestPositionsSet() {
+    assertThatThrownBy(
+            () ->
+                TrackingBuilder.from(manifestSourceTracking(), 999L)
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
+                    .dvUpdated())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
+
+    assertThatThrownBy(
+            () ->
+                TrackingBuilder.from(manifestSourceTracking(), 999L)
+                    .replacedPositions(ByteBuffer.wrap(new byte[] {1}))
+                    .dvUpdated())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
+  }
+
+  @Test
+  void testBuilderRejectsNullSource() {
+    assertThatThrownBy(() -> TrackingBuilder.from(null, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid source tracking: null");
+  }
+
+  @Test
+  void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
+    Tracking missingBoth = TrackingBuilder.added(42L).build();
+
+    assertThatThrownBy(() -> TrackingBuilder.from(missingBoth, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: data sequence number is null");
+
+    assertThatThrownBy(() -> TrackingBuilder.deleted(missingBoth, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: data sequence number is null");
+
+    assertThatThrownBy(() -> TrackingBuilder.replaced(missingBoth, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: data sequence number is null");
+
+    TrackingStruct missingFileSeq =
+        new TrackingStruct(EntryStatus.ADDED, 42L, 10L, null, null, null, null, null);
+
+    assertThatThrownBy(() -> TrackingBuilder.from(missingFileSeq, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
+
+    assertThatThrownBy(() -> TrackingBuilder.deleted(missingFileSeq, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
+
+    assertThatThrownBy(() -> TrackingBuilder.replaced(missingFileSeq, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
+  }
+
+  private static Stream<Arguments> terminalTransitionCases() {
+    Consumer<Tracking> builderCall = source -> TrackingBuilder.from(source, 1L);
+    Consumer<Tracking> deletedCall = source -> TrackingBuilder.deleted(source, 1L);
+    Consumer<Tracking> replacedCall = source -> TrackingBuilder.replaced(source, 1L);
+    return Stream.of(
+        Arguments.of(EntryStatus.DELETED, builderCall),
+        Arguments.of(EntryStatus.DELETED, deletedCall),
+        Arguments.of(EntryStatus.DELETED, replacedCall),
+        Arguments.of(EntryStatus.REPLACED, builderCall),
+        Arguments.of(EntryStatus.REPLACED, deletedCall),
+        Arguments.of(EntryStatus.REPLACED, replacedCall));
+  }
+
+  @ParameterizedTest
+  @MethodSource("terminalTransitionCases")
+  void testRejectsTransitionsFromTerminalStatus(
+      EntryStatus sourceStatus, Consumer<Tracking> factoryCall) {
+    Tracking source = sourceTrackingWithStatus(sourceStatus);
+    assertThatThrownBy(() -> factoryCall.accept(source))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot revive non-live entry with status " + sourceStatus);
+  }
+
+  @Test
+  void testExistingToExistingIsAllowed() {
+    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
+
+    Tracking existing = TrackingBuilder.from(existingSource, 1L).build();
+
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
+  }
+
+  @Test
+  void testExistingToTerminalTransitions() {
+    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
+
+    Tracking deleted = TrackingBuilder.deleted(existingSource, 999L);
+    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
+    assertThat(deleted.snapshotId()).isEqualTo(999L);
+
+    Tracking replaced = TrackingBuilder.replaced(existingSource, 999L);
+    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
+    assertThat(replaced.snapshotId()).isEqualTo(999L);
+  }
+
+  @Test
+  void testExistingPreservesSourceSnapshotId() {
+    Tracking source = sourceTracking();
+    Tracking existing = TrackingBuilder.from(source, 999L).build();
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
+  }
+
+  @Test
+  void testCarryForwardFromModifiedSourceChangesToExisting() {
+    Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
+    Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
+    assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(carried.snapshotId()).isEqualTo(modifiedSource.snapshotId()).isNotEqualTo(999L);
+    assertThat(carried.dvSnapshotId()).isEqualTo(modifiedSource.dvSnapshotId()).isNotEqualTo(999L);
+    assertThat(carried.dataSequenceNumber()).isEqualTo(modifiedSource.dataSequenceNumber());
+    assertThat(carried.fileSequenceNumber()).isEqualTo(modifiedSource.fileSequenceNumber());
+    assertThat(carried.firstRowId()).isEqualTo(modifiedSource.firstRowId());
+  }
+
+  @Test
+  void testManifestDVPositionsProduceModified() {
+    ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1, 2});
+
+    Tracking addedSource = manifestSourceTracking();
+    Tracking modified =
+        TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
+    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
+    // the entry snapshot id is preserved; only the DV snapshot id advances to the commit snapshot
+    assertThat(modified.snapshotId()).isEqualTo(addedSource.snapshotId()).isNotEqualTo(999L);
+    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
+    assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
+  }
+
+  private static TrackingStruct sourceTracking() {
+    return sourceTrackingWithStatus(EntryStatus.ADDED);
+  }
+
+  private static TrackingStruct sourceTrackingWithStatus(EntryStatus status) {
+    return new TrackingStruct(status, 42L, 10L, 10L, 43L, 1000L, null, null);
+  }
+
+  private static TrackingStruct manifestSourceTracking() {
+    return new TrackingStruct(EntryStatus.ADDED, 42L, 10L, 10L, null, 1000L, null, null);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -24,43 +24,25 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class TestTrackingStruct {
+  private static final byte[] DELETED_POSITIONS = new byte[] {1, 2};
+  private static final byte[] REPLACED_POSITIONS = new byte[] {3, 4};
 
-  // Ordinals looked up from Tracking.schema() so tests don't hard-code positions.
-  private static final List<Types.NestedField> TRACKING_FIELDS = Tracking.schema().fields();
-  private static final int STATUS_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.STATUS);
-  private static final int SNAPSHOT_ID_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.SNAPSHOT_ID);
-  private static final int DATA_SEQUENCE_NUMBER_ORDINAL =
-      TRACKING_FIELDS.indexOf(Tracking.SEQUENCE_NUMBER);
-  private static final int FILE_SEQUENCE_NUMBER_ORDINAL =
-      TRACKING_FIELDS.indexOf(Tracking.FILE_SEQUENCE_NUMBER);
-  private static final int DV_SNAPSHOT_ID_ORDINAL =
-      TRACKING_FIELDS.indexOf(Tracking.DV_SNAPSHOT_ID);
-  private static final int FIRST_ROW_ID_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.FIRST_ROW_ID);
-  private static final int DELETED_POSITIONS_ORDINAL =
-      TRACKING_FIELDS.indexOf(Tracking.DELETED_POSITIONS);
-  private static final int REPLACED_POSITIONS_ORDINAL =
-      TRACKING_FIELDS.indexOf(Tracking.REPLACED_POSITIONS);
+  private static final int MANIFEST_POSITION_ORDINAL = Tracking.schema().fields().size();
 
   @Test
   void testFieldAccess() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 11L);
-    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
-    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+    tracking.setManifestLocation("manifest-location");
+    tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
@@ -68,17 +50,65 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
     assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
     assertThat(tracking.firstRowId()).isEqualTo(1000L);
-    assertThat(tracking.deletedPositions()).isNull();
-    assertThat(tracking.replacedPositions()).isNull();
+    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
+    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
+    assertThat(tracking.manifestLocation()).isEqualTo("manifest-location");
+    assertThat(tracking.manifestPos()).isEqualTo(7L);
+  }
+
+  @Test
+  void testSetByPosition() {
+    TrackingStruct tracking = new TrackingStruct();
+
+    tracking.set(pos("status"), EntryStatus.ADDED.id());
+    tracking.set(pos("snapshot_id"), 42L);
+    tracking.set(pos("sequence_number"), 10L);
+    tracking.set(pos("file_sequence_number"), 11L);
+    tracking.set(pos("dv_snapshot_id"), 43L);
+    tracking.set(pos("first_row_id"), 1000L);
+    tracking.set(pos("deleted_positions"), ByteBuffer.wrap(DELETED_POSITIONS));
+    tracking.set(pos("replaced_positions"), ByteBuffer.wrap(REPLACED_POSITIONS));
+    tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
+
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.firstRowId()).isEqualTo(1000L);
+    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
+    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
+    assertThat(tracking.manifestPos()).isEqualTo(7L);
+  }
+
+  @Test
+  void testGetByPosition() {
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+    tracking.setManifestLocation("manifest-location");
+    tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
+
+    assertThat(tracking.get(pos("status"), Integer.class)).isEqualTo(EntryStatus.ADDED.id());
+    assertThat(tracking.get(pos("snapshot_id"), Long.class)).isEqualTo(42L);
+    assertThat(tracking.get(pos("sequence_number"), Long.class)).isEqualTo(10L);
+    assertThat(tracking.get(pos("file_sequence_number"), Long.class)).isEqualTo(11L);
+    assertThat(tracking.get(pos("dv_snapshot_id"), Long.class)).isEqualTo(43L);
+    assertThat(tracking.get(pos("first_row_id"), Long.class)).isEqualTo(1000L);
+    assertThat(tracking.get(pos("deleted_positions"), ByteBuffer.class))
+        .isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
+    assertThat(tracking.get(pos("replaced_positions"), ByteBuffer.class))
+        .isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
+    assertThat(tracking.get(MANIFEST_POSITION_ORDINAL, Long.class)).isEqualTo(7L);
   }
 
   @Test
   void testCopy() {
-    Tracking tracking =
-        TrackingBuilder.from(manifestSourceTracking(), 1L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.MODIFIED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+    tracking.setManifestLocation("manifest-location");
+    tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
     Tracking copy = tracking.copy();
 
@@ -90,24 +120,18 @@ class TestTrackingStruct {
     assertThat(copy.firstRowId()).isEqualTo(tracking.firstRowId());
     assertThat(copy.deletedPositions()).isEqualTo(tracking.deletedPositions());
     assertThat(copy.replacedPositions()).isEqualTo(tracking.replacedPositions());
+    assertThat(copy.manifestLocation()).isEqualTo(tracking.manifestLocation());
+    assertThat(copy.manifestPos()).isEqualTo(tracking.manifestPos());
 
     // verify deep copy of ByteBuffer backing arrays
     assertThat(copy.deletedPositions().array()).isNotSameAs(tracking.deletedPositions().array());
     assertThat(copy.replacedPositions().array()).isNotSameAs(tracking.replacedPositions().array());
   }
 
-  @ParameterizedTest
-  @EnumSource(EntryStatus.class)
-  void testAllStatuses(EntryStatus status) {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, status.id());
-    assertThat(tracking.status()).isEqualTo(status);
-  }
-
   @Test
   void testInheritSnapshotId() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -117,8 +141,8 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSequenceNumberForAddedEntries() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -129,10 +153,8 @@ class TestTrackingStruct {
 
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 5L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 6L);
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.EXISTING, 42L, 5L, 6L, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -143,10 +165,8 @@ class TestTrackingStruct {
 
   @Test
   void testDoNotInheritSequenceNumberForModifiedEntries() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.MODIFIED.id());
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 5L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 6L);
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.MODIFIED, 42L, 5L, 6L, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -157,11 +177,8 @@ class TestTrackingStruct {
 
   @Test
   void testExplicitValuesOverrideInheritance() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    tracking.set(SNAPSHOT_ID_ORDINAL, 200L);
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 75L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 76L);
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, 200L, 75L, 76L, null, null, null, null);
 
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
@@ -173,14 +190,11 @@ class TestTrackingStruct {
 
   @Test
   void testInheritFromRejectsUnequalSequenceNumbers() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
 
-    TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
-    manifestTracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    manifestTracking.set(SNAPSHOT_ID_ORDINAL, 100L);
-    manifestTracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 50L);
-    manifestTracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 60L);
+    TrackingStruct manifestTracking =
+        new TrackingStruct(EntryStatus.ADDED, 100L, 50L, 60L, null, null, null, null);
 
     assertThatThrownBy(() -> tracking.inheritFrom(manifestTracking))
         .isInstanceOf(IllegalArgumentException.class)
@@ -189,8 +203,8 @@ class TestTrackingStruct {
 
   @Test
   void testNoDefaultingWithoutInheritance() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -200,8 +214,8 @@ class TestTrackingStruct {
 
   @Test
   void testInheritFromNullIsNoOp() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
     tracking.inheritFrom(null);
 
@@ -212,274 +226,23 @@ class TestTrackingStruct {
   }
 
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    tracking.set(SNAPSHOT_ID_ORDINAL, snapshotId);
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, sequenceNumber);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, sequenceNumber);
-    return tracking;
-  }
-
-  @Test
-  void testAddedWithSameCommitDvStaysAdded() {
-    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
-
-    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(tracking.snapshotId()).isEqualTo(42L);
-    assertThat(tracking.dvSnapshotId()).isEqualTo(42L);
-    assertThat(tracking.deletedPositions()).isNull();
-    assertThat(tracking.replacedPositions()).isNull();
-    // sequence numbers and firstRowId remain null; populated by inheritance
-    assertThat(tracking.dataSequenceNumber()).isNull();
-    assertThat(tracking.fileSequenceNumber()).isNull();
-    assertThat(tracking.firstRowId()).isNull();
-  }
-
-  @Test
-  void testExistingBuilderPreservesSourceFields() {
-    Tracking source = sourceTracking();
-
-    Tracking existing = TrackingBuilder.from(source, 1L).build();
-
-    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
-    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
-    assertThat(existing.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
-    assertThat(existing.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
-    assertThat(existing.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
-    assertThat(existing.firstRowId()).isEqualTo(source.firstRowId());
-  }
-
-  @Test
-  void testDeleteUpdatesSnapshotIdAndPreservesRest() {
-    Tracking source = sourceTracking();
-
-    Tracking deleted = TrackingBuilder.deleted(source, 999L);
-
-    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
-    assertThat(deleted.snapshotId()).isEqualTo(999L);
-    assertThat(deleted.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
-    assertThat(deleted.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
-    assertThat(deleted.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
-    assertThat(deleted.firstRowId()).isEqualTo(source.firstRowId());
-  }
-
-  @Test
-  void testReplaceUpdatesSnapshotIdAndPreservesRest() {
-    Tracking source = sourceTracking();
-
-    Tracking replaced = TrackingBuilder.replaced(source, 999L);
-
-    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
-    assertThat(replaced.snapshotId()).isEqualTo(999L);
-    assertThat(replaced.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
-    assertThat(replaced.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
-    assertThat(replaced.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
-    assertThat(replaced.firstRowId()).isEqualTo(source.firstRowId());
-  }
-
-  @Test
-  void testSourceDvPositionsAreNotCarriedForward() {
-    TrackingStruct source = sourceTracking();
-    source.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
-    source.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
-
-    Tracking existing = TrackingBuilder.from(source, 1L).build();
-    assertThat(existing.deletedPositions()).isNull();
-    assertThat(existing.replacedPositions()).isNull();
-
-    Tracking deleted = TrackingBuilder.deleted(source, 999L);
-    assertThat(deleted.deletedPositions()).isNull();
-    assertThat(deleted.replacedPositions()).isNull();
-
-    Tracking replaced = TrackingBuilder.replaced(source, 999L);
-    assertThat(replaced.deletedPositions()).isNull();
-    assertThat(replaced.replacedPositions()).isNull();
-  }
-
-  @Test
-  void testDvUpdatedProducesModifiedAndAdvancesDvSnapshotId() {
-    Tracking source = sourceTracking();
-    Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
-
-    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    // the entry snapshot id is preserved so we still know when the base file was added
-    assertThat(modified.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
-    // only the DV snapshot id advances to the commit snapshot
-    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
-  }
-
-  @Test
-  void testManifestDVMutatorsRejectedOnAdded() {
-    assertThatThrownBy(
-            () -> TrackingBuilder.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on ADDED entry");
-
-    assertThatThrownBy(
-            () -> TrackingBuilder.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on ADDED entry");
-  }
-
-  @Test
-  void testDvUpdatedRejectedWhenManifestPositionsSet() {
-    assertThatThrownBy(
-            () ->
-                TrackingBuilder.from(manifestSourceTracking(), 999L)
-                    .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
-                    .dvUpdated())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
-
-    assertThatThrownBy(
-            () ->
-                TrackingBuilder.from(manifestSourceTracking(), 999L)
-                    .replacedPositions(ByteBuffer.wrap(new byte[] {1}))
-                    .dvUpdated())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
-  }
-
-  @Test
-  void testBuilderRejectsNullSource() {
-    assertThatThrownBy(() -> TrackingBuilder.from(null, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid source tracking: null");
-  }
-
-  @Test
-  void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
-    Tracking missingBoth = TrackingBuilder.added(42L).build();
-
-    assertThatThrownBy(() -> TrackingBuilder.from(missingBoth, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: data sequence number is null");
-
-    assertThatThrownBy(() -> TrackingBuilder.deleted(missingBoth, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: data sequence number is null");
-
-    assertThatThrownBy(() -> TrackingBuilder.replaced(missingBoth, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: data sequence number is null");
-
-    TrackingStruct missingFileSeq = new TrackingStruct(Tracking.schema());
-    missingFileSeq.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    missingFileSeq.set(SNAPSHOT_ID_ORDINAL, 42L);
-    missingFileSeq.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
-
-    assertThatThrownBy(() -> TrackingBuilder.from(missingFileSeq, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: file sequence number is null");
-
-    assertThatThrownBy(() -> TrackingBuilder.deleted(missingFileSeq, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: file sequence number is null");
-
-    assertThatThrownBy(() -> TrackingBuilder.replaced(missingFileSeq, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid tracking source: file sequence number is null");
-  }
-
-  private static Stream<Arguments> terminalTransitionCases() {
-    Consumer<Tracking> builderCall = source -> TrackingBuilder.from(source, 1L);
-    Consumer<Tracking> deletedCall = source -> TrackingBuilder.deleted(source, 1L);
-    Consumer<Tracking> replacedCall = source -> TrackingBuilder.replaced(source, 1L);
-    return Stream.of(
-        Arguments.of(EntryStatus.DELETED, builderCall),
-        Arguments.of(EntryStatus.DELETED, deletedCall),
-        Arguments.of(EntryStatus.DELETED, replacedCall),
-        Arguments.of(EntryStatus.REPLACED, builderCall),
-        Arguments.of(EntryStatus.REPLACED, deletedCall),
-        Arguments.of(EntryStatus.REPLACED, replacedCall));
+    return new TrackingStruct(
+        EntryStatus.ADDED, snapshotId, sequenceNumber, sequenceNumber, null, null, null, null);
   }
 
   @ParameterizedTest
-  @MethodSource("terminalTransitionCases")
-  void testRejectsTransitionsFromTerminalStatus(
-      EntryStatus sourceStatus, Consumer<Tracking> factoryCall) {
-    Tracking source = sourceTrackingWithStatus(sourceStatus);
-    assertThatThrownBy(() -> factoryCall.accept(source))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot revive non-live entry with status " + sourceStatus);
-  }
+  @EnumSource(EntryStatus.class)
+  void testIsLiveDelegatesToStatus(EntryStatus status) {
+    TrackingStruct tracking = new TrackingStruct(status, null, null, null, null, null, null, null);
 
-  @Test
-  void testExistingToExistingIsAllowed() {
-    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
-
-    Tracking existing = TrackingBuilder.from(existingSource, 1L).build();
-
-    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
-    assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
-  }
-
-  @Test
-  void testExistingToTerminalTransitions() {
-    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
-
-    Tracking deleted = TrackingBuilder.deleted(existingSource, 999L);
-    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
-    assertThat(deleted.snapshotId()).isEqualTo(999L);
-
-    Tracking replaced = TrackingBuilder.replaced(existingSource, 999L);
-    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
-    assertThat(replaced.snapshotId()).isEqualTo(999L);
-  }
-
-  @Test
-  void testExistingPreservesSourceSnapshotId() {
-    Tracking source = sourceTracking();
-    Tracking existing = TrackingBuilder.from(source, 999L).build();
-    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
-    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
-  }
-
-  @Test
-  void testCarryForwardFromModifiedSourceChangesToExisting() {
-    Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
-    Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
-    assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
-    assertThat(carried.snapshotId()).isEqualTo(modifiedSource.snapshotId()).isNotEqualTo(999L);
-    assertThat(carried.dvSnapshotId()).isEqualTo(modifiedSource.dvSnapshotId()).isNotEqualTo(999L);
-    assertThat(carried.dataSequenceNumber()).isEqualTo(modifiedSource.dataSequenceNumber());
-    assertThat(carried.fileSequenceNumber()).isEqualTo(modifiedSource.fileSequenceNumber());
-    assertThat(carried.firstRowId()).isEqualTo(modifiedSource.firstRowId());
-  }
-
-  @Test
-  void testManifestDVPositionsProduceModified() {
-    ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1, 2});
-
-    Tracking addedSource = manifestSourceTracking();
-    Tracking modified =
-        TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
-    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    // the entry snapshot id is preserved; only the DV snapshot id advances to the commit snapshot
-    assertThat(modified.snapshotId()).isEqualTo(addedSource.snapshotId()).isNotEqualTo(999L);
-    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
-    assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
-  }
-
-  @Test
-  void testIsLiveDelegatesToStatus() {
-    assertThat(sourceTrackingWithStatus(EntryStatus.ADDED).isLive()).isTrue();
-    assertThat(sourceTrackingWithStatus(EntryStatus.DELETED).isLive()).isFalse();
+    assertThat(tracking.isLive()).isEqualTo(status.isLive());
   }
 
   @Test
   void testInternalSetIgnoresUnknownOrdinal() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 11L);
-    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
-    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
-    tracking.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
-    tracking.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
 
     // unknown ordinals from a newer format version are silently ignored
     tracking.internalSet(99, "value from a newer format");
@@ -491,8 +254,8 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
     assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
     assertThat(tracking.firstRowId()).isEqualTo(1000L);
-    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
-    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
+    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
+    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
   }
 
   @Test
@@ -514,84 +277,40 @@ class TestTrackingStruct {
     assertThat(tracking.get(1, Long.class)).isEqualTo(1000L);
   }
 
-  @Test
-  void testJavaSerializationRoundTripForDataFile() throws IOException, ClassNotFoundException {
-    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  void testSerializationRoundTrip(TestHelpers.RoundTripSerializer<Tracking> roundTripSerializer)
+      throws IOException, ClassNotFoundException {
+    TrackingStruct tracking =
+        new TrackingStruct(
+            EntryStatus.MODIFIED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
+    tracking.setManifestLocation("manifest-location");
+    tracking.set(MANIFEST_POSITION_ORDINAL, 7L);
 
-    Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
-
-    assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(42L);
-    assertThat(deserialized.deletedPositions()).isNull();
-    assertThat(deserialized.replacedPositions()).isNull();
-  }
-
-  @Test
-  void testJavaSerializationRoundTripForManifest() throws IOException, ClassNotFoundException {
-    Tracking tracking =
-        TrackingBuilder.from(manifestSourceTracking(), 1L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
-
-    Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
+    Tracking deserialized = roundTripSerializer.apply(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
-    assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
-    assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
-  }
-
-  @Test
-  void testKryoSerializationRoundTripForDataFile() throws IOException {
-    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
-
-    Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
-
-    assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(42L);
-    assertThat(deserialized.deletedPositions()).isNull();
-    assertThat(deserialized.replacedPositions()).isNull();
+    assertThat(deserialized.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(deserialized.fileSequenceNumber()).isEqualTo(11L);
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(43L);
+    assertThat(deserialized.firstRowId()).isEqualTo(1000L);
+    assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(DELETED_POSITIONS));
+    assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(REPLACED_POSITIONS));
+    assertThat(deserialized.manifestLocation()).isEqualTo("manifest-location");
+    assertThat(deserialized.manifestPos()).isEqualTo(7L);
   }
 
-  @Test
-  void testKryoSerializationRoundTripForManifest() throws IOException {
-    Tracking tracking =
-        TrackingBuilder.from(manifestSourceTracking(), 1L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
+  // Returns the positions of fields within the Tracking schema by name. For internal fields like
+  // '_pos' introduce a constant instead of using this function.
+  private static int pos(String fieldName) {
+    List<Types.NestedField> fields = Tracking.schema().fields();
+    for (int i = 0; i < fields.size(); i++) {
+      if (fields.get(i).name().equals(fieldName)) {
+        return i;
+      }
+    }
 
-    Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
-
-    assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
-    assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
-    assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
-  }
-
-  private static TrackingStruct sourceTracking() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
-    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
-    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 10L);
-    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
-    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
-    return tracking;
-  }
-
-  private static TrackingStruct sourceTrackingWithStatus(EntryStatus status) {
-    TrackingStruct tracking = sourceTracking();
-    tracking.set(STATUS_ORDINAL, status.id());
-    return tracking;
-  }
-
-  private static TrackingStruct manifestSourceTracking() {
-    TrackingStruct tracking = sourceTracking();
-    tracking.set(DV_SNAPSHOT_ID_ORDINAL, null);
-    return tracking;
+    throw new IllegalArgumentException("Field not found in schema: " + fieldName);
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
@@ -293,8 +293,7 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T>, 
       EncryptedOutputFile file, PartitionSpec spec, StructLike partition) {
     EncryptionKeyMetadata keyMetadata = file.keyMetadata();
     Map<String, String> properties = table == null ? ImmutableMap.of() : table.properties();
-    MetricsConfig metricsConfig =
-        table == null ? MetricsConfig.forPositionDelete() : MetricsConfig.forPositionDelete(table);
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
     try {
       switch (deleteFileFormat) {

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -171,7 +171,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   public FileAppender<Record> newAppender(
       EncryptedOutputFile encryptedOutputFile, FileFormat fileFormat) {
     MetricsConfig metricsConfig =
-        table != null ? MetricsConfig.forTable(table) : MetricsConfig.fromProperties(config);
+        table != null ? MetricsConfig.forTable(table) : MetricsConfig.from(config, null, null);
 
     try {
       switch (fileFormat) {
@@ -233,7 +233,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
         eqDeleteRowSchema,
         "Equality delete row schema shouldn't be null when creating equality-delete writer");
     MetricsConfig metricsConfig =
-        table != null ? MetricsConfig.forTable(table) : MetricsConfig.fromProperties(config);
+        table != null ? MetricsConfig.forTable(table) : MetricsConfig.from(config, null, null);
 
     try {
       switch (format) {
@@ -287,10 +287,7 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
   @Override
   public PositionDeleteWriter<Record> newPosDeleteWriter(
       EncryptedOutputFile file, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig =
-        table != null
-            ? MetricsConfig.forPositionDelete(table)
-            : MetricsConfig.fromProperties(config);
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
     try {
       switch (format) {

--- a/data/src/main/java/org/apache/iceberg/data/GenericFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericFileWriterFactory.java
@@ -241,10 +241,7 @@ public class GenericFileWriterFactory extends RegistryBasedFileWriterFactory<Rec
       LOG.warn(
           "Deprecated feature used. Position delete row schema is used to create the position delete writer.");
       Map<String, String> properties = table == null ? ImmutableMap.of() : table.properties();
-      MetricsConfig metricsConfig =
-          table == null
-              ? MetricsConfig.forPositionDelete()
-              : MetricsConfig.forPositionDelete(table);
+      MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
       try {
         return switch (format) {

--- a/data/src/main/java/org/apache/iceberg/data/RegistryBasedFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/RegistryBasedFileWriterFactory.java
@@ -160,8 +160,7 @@ public abstract class RegistryBasedFileWriterFactory<T, S>
       EncryptedOutputFile file, PartitionSpec spec, StructLike partition) {
     EncryptionKeyMetadata keyMetadata = file.keyMetadata();
     Map<String, String> properties = table != null ? table.properties() : ImmutableMap.of();
-    MetricsConfig metricsConfig =
-        table != null ? MetricsConfig.forPositionDelete(table) : MetricsConfig.forPositionDelete();
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
     try {
       FileWriterBuilder<PositionDeleteWriter<T>, ?> builder =

--- a/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestFileWriterFactory.java
@@ -53,7 +53,6 @@ import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceSet;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.SerializationUtil;
@@ -301,23 +300,17 @@ public abstract class TestFileWriterFactory<T> extends WriterTestBase<T> {
     } else {
       assertThat(referencedDataFiles).hasSize(1);
       assertThat(deleteFile.lowerBounds())
-          .hasSize(4)
+          .hasSize(2)
           .containsKey(DELETE_FILE_PATH.fieldId())
           .containsKey(DELETE_FILE_POS.fieldId());
-      for (Types.NestedField column : table.schema().columns()) {
-        assertThat(deleteFile.lowerBounds()).containsKey(column.fieldId());
-      }
       assertThat(deleteFile.upperBounds())
-          .hasSize(4)
+          .hasSize(2)
           .containsKey(DELETE_FILE_PATH.fieldId())
           .containsKey(DELETE_FILE_POS.fieldId());
-      for (Types.NestedField column : table.schema().columns()) {
-        assertThat(deleteFile.upperBounds()).containsKey(column.fieldId());
-      }
       // ORC also contains metrics for the deleted row struct, not just actual data fields
-      assertThat(deleteFile.columnSizes()).hasSizeGreaterThanOrEqualTo(4);
-      assertThat(deleteFile.valueCounts()).hasSizeGreaterThanOrEqualTo(2);
-      assertThat(deleteFile.nullValueCounts()).hasSizeGreaterThanOrEqualTo(2);
+      assertThat(deleteFile.columnSizes()).hasSizeGreaterThanOrEqualTo(2);
+      assertThat(deleteFile.valueCounts()).isNull();
+      assertThat(deleteFile.nullValueCounts()).isNull();
       assertThat(deleteFile.nanValueCounts()).isNull();
     }
 

--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -206,8 +206,8 @@ public abstract class TestWriterMetrics<T> {
     DeleteFile deleteFile = deleteWriter.toDeleteFile();
 
     // should have NO bounds for path and position as the file covers multiple data paths
-    checkNotExistingRowStatistics(deleteFile.lowerBounds());
-    checkNotExistingRowStatistics(deleteFile.upperBounds());
+    assertThat(deleteFile.lowerBounds()).isNull();
+    assertThat(deleteFile.upperBounds()).isNull();
   }
 
   @TestTemplate
@@ -353,21 +353,11 @@ public abstract class TestWriterMetrics<T> {
   }
 
   protected void checkRowStatistics(Map<Integer, ByteBuffer> bounds) {
-    assertThat(bounds).hasSize(4);
-    assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), bounds.get(1)))
-        .isEqualTo(3);
+    assertThat(bounds).hasSize(2);
+    assertThat(bounds).doesNotContainKey(1);
     assertThat(bounds).doesNotContainKey(2);
     assertThat(bounds).doesNotContainKey(3);
     assertThat(bounds).doesNotContainKey(4);
-    assertThat((long) Conversions.fromByteBuffer(Types.LongType.get(), bounds.get(5)))
-        .isEqualTo(3L);
-  }
-
-  protected void checkNotExistingRowStatistics(Map<Integer, ByteBuffer> bounds) {
-    assertThat(bounds).hasSize(2);
-    assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), bounds.get(1)))
-        .isEqualTo(3);
-    assertThat((long) Conversions.fromByteBuffer(Types.LongType.get(), bounds.get(5)))
-        .isEqualTo(3L);
+    assertThat(bounds).doesNotContainKey(5);
   }
 }

--- a/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
@@ -144,12 +144,12 @@ public class TestOrcMetrics extends TestMetrics {
 
   @Override
   protected <T> void assertBounds(
-      int fieldId, Type type, T lowerBound, T upperBound, MetricsWithStats metricsWithStats) {
+      int fieldId, Type type, T lowerBound, T upperBound, Metrics metrics) {
     if (isBinaryType(type)) {
-      assertThat(metricsWithStats.metrics().lowerBounds()).doesNotContainKey(fieldId);
-      assertThat(metricsWithStats.metrics().upperBounds()).doesNotContainKey(fieldId);
+      assertThat(metrics.lowerBounds()).doesNotContainKey(fieldId);
+      assertThat(metrics.upperBounds()).doesNotContainKey(fieldId);
       return;
     }
-    super.assertBounds(fieldId, type, lowerBound, upperBound, metricsWithStats);
+    super.assertBounds(fieldId, type, lowerBound, upperBound, metrics);
   }
 }

--- a/docs/docs/flink-maintenance.md
+++ b/docs/docs/flink-maintenance.md
@@ -82,6 +82,50 @@ Used to remove files which are not referenced in any metadata files of an Iceber
     .deleteBatchSize(1000))
 ```
 
+#### ConvertEqualityDeletes
+Converts equality delete files staged on a source branch into deletion vectors (DVs) on the target branch. Requires table format version >= 3 (which introduces DVs). This is typically used together with the Flink `IcebergSink`, which writes new data files and equality deletes to a staging branch; the converter then resolves the equality deletes into row-position DVs and commits the data files together with the DVs to the target branch.
+
+The pipeline runs a single conversion cycle for every trigger event. Internally it is split into parallel stages (planner → reader → PK index → DV writer → committer), and it uses the same maintenance-framework lock as other tasks to guarantee mutual exclusion with concurrent maintenance operations (e.g. compaction) on the same table.
+
+```java
+.add(ConvertEqualityDeletes.builder()
+    .stagingBranch("staging")
+    .equalityFieldColumns(ImmutableList.of("id"))
+    .scheduleOnEqDeleteFileCount(10)
+    .parallelism(4))
+```
+
+Notes:
+
+**Prerequisites and staging-branch layout**
+
+- Table format version must be `>= 3` (the version that introduces deletion vectors). This is validated at job startup so a wrongly-configured job fails fast instead of silently doing nothing.
+- Row lineage is not currently supported.
+- The staging branch may contain new data files, equality delete files, and deletion vectors, but **must not** contain V2 positional delete files. The planner throws if it encounters any V2 positional delete on the staging branch.
+- The staging branch **must not remove data files**, i.e. do not run compaction / rewrite on the staging branch. If a staging snapshot removes data files, the cycle fails; run `RewriteDataFiles` on the target branch instead — the shared maintenance lock keeps it safe alongside this task.
+- `equalityFieldColumns` is required, must be non-empty, and must match the equality field columns the writer used to produce the staged equality delete files (see `IcebergSink.Builder#equalityFieldColumns`). Every staged equality delete file's `equalityFieldIds` must exactly equal this set; a mismatch fails the cycle. The partition source columns of every staged equality delete's spec must also be a subset of these equality columns.
+
+**Branch semantics**
+
+- When `stagingBranch` and `targetBranch` are different, the converter reads eq-deletes from the staging branch and commits the resolved data files and DVs to the target branch. The staging branch itself is not modified by this task.
+- When `stagingBranch` and `targetBranch` are equal, the converter operates in-place: it acts as an equality-delete-to-DV compaction on that single branch. On cold start it walks the entire branch history so eq-deletes committed before the converter started are still picked up. Pure-insert snapshots on the shared branch are skipped without running a full cycle.
+- Only one **oldest unprocessed** staging snapshot is processed per trigger. If the writer produces staging snapshots faster than the converter can process them, they queue up on the staging branch. Configure `scheduleOnInterval` / `scheduleOnEqDeleteFileCount` / `scheduleOnCommitCount` (and `TableMaintenance.rateLimit`) accordingly to keep up with the ingestion rate.
+
+**State and restart**
+
+- The PK-index worker keeps a keyed row-position index of the target branch in Flink state and **maintains it incrementally across checkpoints**: each trigger cycle only applies the commits added on the target branch since the last indexed snapshot, and the resulting index is persisted with the next Flink checkpoint. On failover, the worker resumes from the most recent checkpointed index rather than rebuilding from scratch. Its size scales with the number of live rows in the table for the configured equality columns; size Flink state backend, checkpoint storage, and TaskManager memory accordingly. **RocksDB is the preferred state backend** because the PK index can grow beyond the available heap and RocksDB spills to local disk instead of failing with an `OutOfMemoryError`.
+- Full (re)indexing from the target branch head is only triggered in a few cases: cold start with no checkpoint, external commits that advance the target past the currently-indexed snapshot (see below), or when the planner detects that the target branch has diverged from the indexed snapshot (rollback / replace-main / expired marker).
+- The `equalityFieldColumns` set is persisted in operator state. Reconfiguring it across a restart from savepoint is **not supported** and the job will fail fast on restore. Restart from a clean state (no savepoint) if the equality columns change.
+- The committer is intentionally stateless. On restart, the planner rediscovers its position by walking the target branch for the marker property `equality-convert-staging-snapshot` written by the committer. If that marker is no longer reachable on the target branch (target was rolled back, replace-main'ed, or the marker snapshot was expired) the planner fails and requires manual intervention.
+
+**Concurrent commits on the target branch**
+
+- External commits to the target branch (e.g. compaction, direct writes) are detected by `RowDelta.validateFromSnapshot`. A conflicting cycle fails at commit; the next trigger reindexes the worker's PK index from the new target head and retries.
+- **Recommendation: avoid continuous concurrent writers on the target branch.** The conflict check runs at commit time, so a cycle that loses the race has already paid the cost of reading data files, resolving the PK index, and writing DV files — all of which is thrown away on failure. If another writer commits to the target faster than the converter can complete a cycle, cycles can fail repeatedly and never catch up (a livelock), and the abandoned DV files linger until `DeleteOrphanFiles` cleans them up.
+- **Acceptable patterns** (the design assumes one of these):
+    - The Flink `IcebergSink` is the *only* writer to `stagingBranch`, and nothing except this converter writes to `targetBranch`. Other maintenance tasks (compaction, expire snapshots, orphan cleanup) share the same `TriggerLockFactory` so they are serialized with the converter and will not race it.
+    - Occasional external commits to the target branch (e.g. manual fixes, ad-hoc backfill) are fine — the next trigger will reindex and succeed.
+
 ### Lock Management
 
 The `TriggerLockFactory` is essential for coordinating maintenance tasks. It prevents concurrent maintenance operations on the same table, which could lead to conflicts or data corruption. This locking mechanism is necessary even for a single job, as multiple instances of the same task could otherwise conflict.
@@ -238,6 +282,17 @@ env.execute("Table Maintenance Job");
 | `equalAuthorities(Map<String, String>)`  | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority.                                                                                                                                                                                                                                      | Empty map               | Map<String,String> |  
 | `minAge(Duration)`                       | Remove orphan files created before this timestamp                                                                                                                                                                                                                                                                                                                       | 3 days ago              | Duration           |
 | `planningWorkerPoolSize(int)`            | Number of worker threads for planning snapshot expiration                                                                                                                                                                                                                                                                                                               | Shared worker pool      | int                |
+
+#### ConvertEqualityDeletes Configuration
+
+| Method                               | Description                                                                                                                                                                                          | Default Value | Type |
+|--------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|------|
+| `stagingBranch(String)`              | Source branch that holds the equality delete files and their associated data files. **Required.**                                                                                                    | None | String |
+| `targetBranch(String)`               | Target branch where converted data files and DVs are committed.                                                                                                                                      | `main` | String |
+| `equalityFieldColumns(List<String>)` | Equality field column names used to build the primary key index. Must match the equality field columns used by the writer (see `IcebergSink.Builder#equalityFieldColumns`). **Required, non-empty.** | None | List&lt;String&gt; |
+
+!!! note
+    `ConvertEqualityDeletes` requires table format version >= 3 (deletion vectors).
 
 ### Complete Example
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.maintenance.operator;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.state.ListState;
@@ -34,6 +35,7 @@ import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction
 import org.apache.flink.util.Collector;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,6 +99,8 @@ public class EqualityConvertPKIndex
       new ValueStateDescriptor<>("resolveTimestamp", Types.LONG);
   private static final ValueStateDescriptor<Long> RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR =
       new ValueStateDescriptor<>("resolveSequenceNumber", Types.LONG);
+  private static final ListStateDescriptor<Integer> RESOLVE_SPEC_IDS_DESCRIPTOR =
+      new ListStateDescriptor<>("resolveSpecIds", Types.INT);
 
   private transient ValueState<Long> mainSequenceVersion;
   // Resolvable rows for this key. Populated immediately for main data, or from onTimer for
@@ -111,6 +115,9 @@ public class EqualityConvertPKIndex
   // Maximum sequence number among the cycle's RESOLVE_DELETEs for this key. Deletes a
   // data row only when the row's sequence number is below it.
   private transient ValueState<Long> resolveSequenceNumber;
+  // Spec ids of the cycle's RESOLVE_DELETEs for this key. A delete phase may carry same-key deletes
+  // from multiple specs, and each scope must apply.
+  private transient ListState<Integer> resolveSpecIds;
 
   private transient Counter resolvedDeleteNumCounter;
   private transient Counter indexedKeyNumCounter;
@@ -130,6 +137,7 @@ public class EqualityConvertPKIndex
     bufferedRows = getRuntimeContext().getListState(BUFFERED_ROWS_DESCRIPTOR);
     resolveTimestamp = getRuntimeContext().getState(RESOLVE_TIMESTAMP_DESCRIPTOR);
     resolveSequenceNumber = getRuntimeContext().getState(RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR);
+    resolveSpecIds = getRuntimeContext().getListState(RESOLVE_SPEC_IDS_DESCRIPTOR);
     resolvedDeleteNumCounter =
         getRuntimeContext().getMetricGroup().counter(RESOLVED_DELETE_NUM_METRIC);
     indexedKeyNumCounter = getRuntimeContext().getMetricGroup().counter(INDEXED_KEY_NUM_METRIC);
@@ -173,6 +181,10 @@ public class EqualityConvertPKIndex
         if (currentSeq == null || cmd.deleteSequenceNumber() > currentSeq) {
           resolveSequenceNumber.update(cmd.deleteSequenceNumber());
         }
+
+        // Accumulate every delete's scope.
+        // One delete phase can carry same-key deletes from multiple specs.
+        resolveSpecIds.add(cmd.deleteSpecId());
 
         ctx.timerService().registerEventTimeTimer(ts);
       } else {
@@ -223,6 +235,7 @@ public class EqualityConvertPKIndex
         resolveDeletes(out);
         resolveTimestamp.clear();
         resolveSequenceNumber.clear();
+        resolveSpecIds.clear();
       } else {
         applyBufferedRows();
       }
@@ -250,14 +263,22 @@ public class EqualityConvertPKIndex
     // indexed sequence is not comparable to the staging delete's; event-time ordering already
     // prevents false deletion.
     Long deleteSeq = resolveSequenceNumber.value();
+    // A partitioned delete applies only to data rows of the same spec. An unpartitioned delete
+    // (GLOBAL_DELETE_SPEC_ID) applies to every spec. deleteSpecIds holds every scope seen this
+    // cycle (usually one).
+    Set<Integer> deleteSpecIds = Sets.newHashSet(resolveSpecIds.get());
+    boolean globalDelete = deleteSpecIds.contains(IndexCommand.GLOBAL_DELETE_SPEC_ID);
     List<DVPosition> nonEligible = Lists.newArrayList();
     int count = 0;
     for (DVPosition pos : dataRowPositions.get()) {
-      if (stagingOnTargetBranch && deleteSeq != null && pos.dataSequenceNumber() >= deleteSeq) {
-        nonEligible.add(pos);
-      } else {
+      boolean specMatch = globalDelete || deleteSpecIds.contains(pos.specId());
+      boolean sequenceMatch =
+          !stagingOnTargetBranch || deleteSeq == null || pos.dataSequenceNumber() < deleteSeq;
+      if (specMatch && sequenceMatch) {
         out.collect(pos);
         count++;
+      } else {
+        nonEligible.add(pos);
       }
     }
 
@@ -270,5 +291,6 @@ public class EqualityConvertPKIndex
     bufferedRows.clear();
     resolveTimestamp.clear();
     resolveSequenceNumber.clear();
+    resolveSpecIds.clear();
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
@@ -151,7 +151,9 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
 
     int specId = file.specId();
     StructLike partition = file.partition();
-    Types.StructType partitionType = table.specs().get(specId).partitionType();
+    // Use the planner-serialized task spec, not the reader's table, which is loaded once and may
+    // lack specs added after startup.
+    Types.StructType partitionType = task.spec().partitionType();
     byte[] partitionBytes = fieldSerializer.encodePartition(partition, partitionType);
 
     InputFile input = table.io().newInputFile(file.location());
@@ -167,8 +169,7 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
           continue;
         }
 
-        SerializedEqualityValues key =
-            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        SerializedEqualityValues key = fieldSerializer.serializeKey(record, keySchema.asStruct());
         out.collect(
             IndexCommand.addDataRow(
                 mainSnapshotId,
@@ -194,17 +195,20 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
     ContentFile<?> file = task.file();
 
     int specId = file.specId();
+    // An unpartitioned equality delete applies globally; a partitioned one applies only within its
+    // own spec. Use the planner-serialized task spec, not the reader's table, which is loaded once
+    // and may lack specs added after startup.
+    int deleteSpecId = task.spec().isUnpartitioned() ? IndexCommand.GLOBAL_DELETE_SPEC_ID : specId;
 
     InputFile input = table.io().newInputFile(file.location());
     ReadBuilder<Record, Schema> builder =
         FormatModelRegistry.readBuilder(file.format(), Record.class, input);
     try (CloseableIterable<Record> records = builder.project(keySchema).reuseContainers().build()) {
       for (Record record : records) {
-        SerializedEqualityValues key =
-            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        SerializedEqualityValues key = fieldSerializer.serializeKey(record, keySchema.asStruct());
         out.collect(
             IndexCommand.resolveDelete(
-                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber));
+                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber, deleteSpecId));
       }
     }
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
@@ -40,6 +40,9 @@ import org.apache.flink.annotation.Internal;
  * <p>{@link #rowPosition} is the data row's location, set for the two add types and null otherwise;
  * the data sequence number it carries lets the worker apply a delete only to older rows. {@code
  * deleteSequenceNumber} is the equality delete's sequence number, set for {@link
+ * Type#RESOLVE_DELETE} and unused (-1) otherwise. {@code deleteSpecId} is the partition spec id of
+ * the delete file, used to scope a partitioned delete to data rows of the same spec; {@link
+ * #GLOBAL_DELETE_SPEC_ID} marks an unpartitioned delete that applies to every spec. Set for {@link
  * Type#RESOLVE_DELETE} and unused (-1) otherwise.
  */
 @Internal
@@ -49,8 +52,12 @@ public record IndexCommand(
     Long mainSequenceNumber,
     SerializedEqualityValues key,
     DVPosition rowPosition,
-    long deleteSequenceNumber)
+    long deleteSequenceNumber,
+    int deleteSpecId)
     implements Serializable {
+
+  /** Spec id sentinel for an unpartitioned equality delete, which applies as a global delete. */
+  public static final int GLOBAL_DELETE_SPEC_ID = -1;
 
   public enum Type {
     ADD_DATA_ROW,
@@ -75,6 +82,7 @@ public record IndexCommand(
         mainSequenceNumber,
         key,
         new DVPosition(filePath, position, specId, partition, dataSequenceNumber),
+        -1,
         -1);
   }
 
@@ -82,12 +90,20 @@ public record IndexCommand(
       Long mainSnapshotId,
       Long mainSequenceNumber,
       SerializedEqualityValues key,
-      long deleteSequenceNumber) {
+      long deleteSequenceNumber,
+      int deleteSpecId) {
     return new IndexCommand(
-        Type.RESOLVE_DELETE, mainSnapshotId, mainSequenceNumber, key, null, deleteSequenceNumber);
+        Type.RESOLVE_DELETE,
+        mainSnapshotId,
+        mainSequenceNumber,
+        key,
+        null,
+        deleteSequenceNumber,
+        deleteSpecId);
   }
 
   public static IndexCommand clearBeforeReindex(long mainSnapshotId, long mainSequenceNumber) {
-    return new IndexCommand(Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1);
+    return new IndexCommand(
+        Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1, -1);
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
@@ -36,8 +36,10 @@ import org.apache.iceberg.types.Types;
  * Serializer for {@link StructLike} tuples. Two entry points:
  *
  * <ul>
- *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues}),
- *       prefixed with the partition spec id so partition evolution keeps specs disjoint.
+ *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues})
+ *       from the equality values alone, so all rows with the same key co-locate on one shard
+ *       regardless of partition spec. Spec scoping of a delete is applied at resolve time, not in
+ *       the key.
  *   <li>{@link #encodePartition} / {@link #decodePartition} serialize partition tuples into bytes.
  * </ul>
  */
@@ -48,12 +50,9 @@ class StructLikeSerializer {
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
   private final DataOutputStream dos = new DataOutputStream(baos);
 
-  public SerializedEqualityValues serializeKey(
-      StructLike key, Types.StructType keyType, int specId) {
+  public SerializedEqualityValues serializeKey(StructLike key, Types.StructType keyType) {
     baos.reset();
     try {
-      dos.writeInt(specId);
-
       List<Types.NestedField> fields = keyType.fields();
       dos.writeInt(fields.size());
       for (Types.NestedField field : fields) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -238,7 +238,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
   @Override
   public PositionDeleteWriter<RowData> newPosDeleteWriter(
       EncryptedOutputFile outputFile, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete(table);
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
     try {
       switch (format) {
         case AVRO:

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
@@ -735,6 +735,62 @@ class TestConvertEqualityDeletes extends MaintenanceTaskTestBase {
   }
 
   @Test
+  void testUnpartitionedDeleteAppliesAcrossPartitionEvolution() throws Exception {
+    // Data is written under a partitioned spec, then the table evolves to unpartitioned. A delete
+    // written under the unpartitioned spec is a global delete and must remove the data row from the
+    // older spec. This only works because the index key is spec-independent (spec scoping happens
+    // at resolve time, where a global delete matches every spec).
+    Table table = createPartitionedTableWithDelete(3);
+    insertPartitioned(table, 1, "a");
+
+    table.updateSpec().removeField("data").commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // writeEqualityDelete writes with the current (now unpartitioned) spec, so the delete is
+    // global.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    assertRecords(table, ImmutableList.of());
+  }
+
+  @Test
+  void testPartitionedDeleteDoesNotApplyAcrossPartitionEvolution() throws Exception {
+    // Inverse of the global case: a partitioned delete under a new spec must NOT remove a data row
+    // written under an older spec. The row survives because resolution is scoped to the delete's
+    // spec.
+    Table table = createPartitionedTableWithDelete(3);
+    insertPartitioned(table, 1, "a");
+
+    // Evolve to a different partition spec so the delete below is written under a new spec id.
+    table.updateSpec().removeField("data").addField("id").commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeIdPartitionedEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // The spec-0 row survives: the delete's spec differs and it is not a global (unpartitioned)
+    // delete.
+    assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+  }
+
+  @Test
   void testStagingPositionDeleteMergedIntoConversionDV() throws Exception {
     Table table = createTableWithDelete(3);
 
@@ -993,6 +1049,21 @@ class TestConvertEqualityDeletes extends MaintenanceTaskTestBase {
 
     PartitionData partition = new PartitionData(table.spec().partitionType());
     partition.set(0, data);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        partition,
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private DeleteFile writeIdPartitionedEqualityDelete(Table table, Integer id, String data)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PartitionData partition = new PartitionData(table.spec().partitionType());
+    partition.set(0, id);
     return FileHelpers.writeDeleteFile(
         table,
         Files.localOutput(file),

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
@@ -22,11 +22,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedBroadcastOperatorTestHarness;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestEqualityConvertPKIndex {
 
@@ -42,6 +46,8 @@ class TestEqualityConvertPKIndex {
   // Data-row sequence below the delete sequence, so existing tests still tombstone on resolve.
   private static final long DATA_SEQ = 1L;
   private static final long DELETE_SEQ = 2L;
+  // Default delete scope for the single-spec tests: global, so it resolves rows of any spec.
+  private static final int GLOBAL = IndexCommand.GLOBAL_DELETE_SPEC_ID;
 
   @Test
   void addDataRowProducesNoOutput() throws Exception {
@@ -90,7 +96,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -136,7 +142,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -154,6 +160,61 @@ class TestEqualityConvertPKIndex {
                 assertThat(pos.position()).isEqualTo(3);
               });
     }
+  }
+
+  @ParameterizedTest(name = "deleteSpecs={0} resolvedSpecs={1}")
+  @MethodSource("deleteSpecScopes")
+  void resolvesDeletesScopedBySpec(List<Integer> deleteSpecIds, List<Integer> resolvedSpecIds)
+      throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // Same key, one row under each of two specs. Partition evolution co-locates them on one
+      // shard.
+      harness.processElement(new StreamRecord<>(addRow("spec0.parquet", 0, 0), 0));
+      harness.processElement(new StreamRecord<>(addRow("spec1.parquet", 1, 1), 0));
+      // All deletes fall in one delete phase (ts 1), so their scopes accumulate.
+      for (int deleteSpecId : deleteSpecIds) {
+        harness.processElement(
+            new StreamRecord<>(
+                IndexCommand.resolveDelete(
+                    MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, deleteSpecId),
+                1));
+      }
+
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues())
+          .extracting(DVPosition::specId)
+          .containsExactlyInAnyOrderElementsOf(resolvedSpecIds);
+    }
+  }
+
+  private static Stream<Arguments> deleteSpecScopes() {
+    return Stream.of(
+        // A partitioned delete resolves only same-spec rows.
+        Arguments.of(List.of(1), List.of(1)),
+        // An unpartitioned (global) delete resolves rows of every spec.
+        Arguments.of(List.of(GLOBAL), List.of(0, 1)),
+        // Two partitioned deletes from different specs in one phase both apply.
+        Arguments.of(List.of(0, 1), List.of(0, 1)),
+        // A global delete scope affects a later partitioned delete in the same phase.
+        Arguments.of(List.of(GLOBAL, 0), List.of(0, 1)));
+  }
+
+  private static IndexCommand addRow(String filePath, long position, int specId) {
+    return IndexCommand.addDataRow(
+        MAIN_SNAPSHOT,
+        MAIN_SEQ,
+        KEY_1,
+        filePath,
+        position,
+        specId,
+        EMPTY_PARTITION,
+        DATA_SEQ,
+        false);
   }
 
   @Test
@@ -178,13 +239,13 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
       assertThat(harness.extractOutputValues()).hasSize(1);
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 2));
       harness.watermark(2);
       assertThat(harness.extractOutputValues()).hasSize(1);
     }
@@ -199,7 +260,7 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -229,7 +290,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              1));
       harness.watermark(1);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -266,7 +329,9 @@ class TestEqualityConvertPKIndex {
       // Resolving KEY_1 against the (now-empty) index emits nothing.
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              2));
       harness.watermark(2);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -299,7 +364,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              2));
       harness.watermark(2);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -350,7 +417,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              3));
       harness.watermark(3);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -383,7 +452,7 @@ class TestEqualityConvertPKIndex {
           new StreamRecord<>(IndexCommand.clearBeforeReindex(999L, 10L), 1));
 
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ), 2));
+          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ, GLOBAL), 2));
       harness.watermark(2);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -429,7 +498,7 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -463,7 +532,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.processElement(
           new StreamRecord<>(
               IndexCommand.addDataRow(
@@ -487,7 +556,7 @@ class TestEqualityConvertPKIndex {
       // A later cycle's delete (ts 3) removes the now-indexed new row.
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 3));
       harness.watermark(3);
       assertThat(harness.extractOutputValues()).hasSize(2);
       assertThat(harness.extractOutputValues().get(1).dataFilePath()).isEqualTo("new.parquet");
@@ -518,7 +587,7 @@ class TestEqualityConvertPKIndex {
               2));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(2);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -560,7 +629,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -601,7 +670,8 @@ class TestEqualityConvertPKIndex {
 
       // Delete at seq 2 tombstones only the older row; the re-insert (seq 3) survives.
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -610,7 +680,8 @@ class TestEqualityConvertPKIndex {
 
       // The survivor stays indexed: a later delete with a higher sequence removes it.
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L), 2));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L, GLOBAL), 2));
       harness.watermark(2);
 
       List<DVPosition> afterSecond = harness.extractOutputValues();
@@ -644,7 +715,8 @@ class TestEqualityConvertPKIndex {
                   false),
               0));
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
@@ -35,8 +35,6 @@ class TestStructLikeSerializer {
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.optional(2, "data", Types.StringType.get()));
 
-  private static final int SPEC_0 = PartitionSpec.unpartitioned().specId();
-
   private final StructLikeSerializer serializer = new StructLikeSerializer();
 
   @Test
@@ -45,8 +43,8 @@ class TestStructLikeSerializer {
     key.set(0, 42);
     key.set(1, "hello");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -60,8 +58,8 @@ class TestStructLikeSerializer {
     record2.set(0, 2);
     record2.set(1, "b");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE);
     assertThat(key1).isNotEqualTo(key2);
   }
 
@@ -78,8 +76,8 @@ class TestStructLikeSerializer {
     GenericRecord record3 = GenericRecord.create(typeWithField3);
     record3.set(0, 42);
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1);
+    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3);
     assertThat(key1).isNotEqualTo(key2);
   }
 
@@ -94,8 +92,8 @@ class TestStructLikeSerializer {
     record.set(0, new BigDecimal("123.45"));
     record.set(1, "test");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -105,8 +103,8 @@ class TestStructLikeSerializer {
     record.set(0, 1);
     record.set(1, null);
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -120,18 +118,8 @@ class TestStructLikeSerializer {
     withValue.set(0, 1);
     withValue.set(1, "");
 
-    assertThat(serializer.serializeKey(withNull, KEY_TYPE, SPEC_0))
-        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE, SPEC_0));
-  }
-
-  @Test
-  void samePkDifferentSpecsAreNotEqual() {
-    GenericRecord pk = GenericRecord.create(KEY_TYPE);
-    pk.set(0, 42);
-    pk.set(1, "x");
-
-    assertThat(serializer.serializeKey(pk, KEY_TYPE, 0))
-        .isNotEqualTo(serializer.serializeKey(pk, KEY_TYPE, 1));
+    assertThat(serializer.serializeKey(withNull, KEY_TYPE))
+        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE));
   }
 
   @Test

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -64,9 +64,4 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected void checkRowStatistics(Map<Integer, ByteBuffer> bounds) {
     assertThat(bounds).hasSize(2);
   }
-
-  @Override
-  protected void checkNotExistingRowStatistics(Map<Integer, ByteBuffer> bounds) {
-    assertThat(bounds).isNull();
-  }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.maintenance.operator;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.api.common.state.ListState;
@@ -34,6 +35,7 @@ import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction
 import org.apache.flink.util.Collector;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,6 +99,8 @@ public class EqualityConvertPKIndex
       new ValueStateDescriptor<>("resolveTimestamp", Types.LONG);
   private static final ValueStateDescriptor<Long> RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR =
       new ValueStateDescriptor<>("resolveSequenceNumber", Types.LONG);
+  private static final ListStateDescriptor<Integer> RESOLVE_SPEC_IDS_DESCRIPTOR =
+      new ListStateDescriptor<>("resolveSpecIds", Types.INT);
 
   private transient ValueState<Long> mainSequenceVersion;
   // Resolvable rows for this key. Populated immediately for main data, or from onTimer for
@@ -111,6 +115,9 @@ public class EqualityConvertPKIndex
   // Maximum sequence number among the cycle's RESOLVE_DELETEs for this key. Deletes a
   // data row only when the row's sequence number is below it.
   private transient ValueState<Long> resolveSequenceNumber;
+  // Spec ids of the cycle's RESOLVE_DELETEs for this key. A delete phase may carry same-key deletes
+  // from multiple specs, and each scope must apply.
+  private transient ListState<Integer> resolveSpecIds;
 
   private transient Counter resolvedDeleteNumCounter;
   private transient Counter indexedKeyNumCounter;
@@ -130,6 +137,7 @@ public class EqualityConvertPKIndex
     bufferedRows = getRuntimeContext().getListState(BUFFERED_ROWS_DESCRIPTOR);
     resolveTimestamp = getRuntimeContext().getState(RESOLVE_TIMESTAMP_DESCRIPTOR);
     resolveSequenceNumber = getRuntimeContext().getState(RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR);
+    resolveSpecIds = getRuntimeContext().getListState(RESOLVE_SPEC_IDS_DESCRIPTOR);
     resolvedDeleteNumCounter =
         getRuntimeContext().getMetricGroup().counter(RESOLVED_DELETE_NUM_METRIC);
     indexedKeyNumCounter = getRuntimeContext().getMetricGroup().counter(INDEXED_KEY_NUM_METRIC);
@@ -173,6 +181,10 @@ public class EqualityConvertPKIndex
         if (currentSeq == null || cmd.deleteSequenceNumber() > currentSeq) {
           resolveSequenceNumber.update(cmd.deleteSequenceNumber());
         }
+
+        // Accumulate every delete's scope.
+        // One delete phase can carry same-key deletes from multiple specs.
+        resolveSpecIds.add(cmd.deleteSpecId());
 
         ctx.timerService().registerEventTimeTimer(ts);
       } else {
@@ -223,6 +235,7 @@ public class EqualityConvertPKIndex
         resolveDeletes(out);
         resolveTimestamp.clear();
         resolveSequenceNumber.clear();
+        resolveSpecIds.clear();
       } else {
         applyBufferedRows();
       }
@@ -250,14 +263,22 @@ public class EqualityConvertPKIndex
     // indexed sequence is not comparable to the staging delete's; event-time ordering already
     // prevents false deletion.
     Long deleteSeq = resolveSequenceNumber.value();
+    // A partitioned delete applies only to data rows of the same spec. An unpartitioned delete
+    // (GLOBAL_DELETE_SPEC_ID) applies to every spec. deleteSpecIds holds every scope seen this
+    // cycle (usually one).
+    Set<Integer> deleteSpecIds = Sets.newHashSet(resolveSpecIds.get());
+    boolean globalDelete = deleteSpecIds.contains(IndexCommand.GLOBAL_DELETE_SPEC_ID);
     List<DVPosition> nonEligible = Lists.newArrayList();
     int count = 0;
     for (DVPosition pos : dataRowPositions.get()) {
-      if (stagingOnTargetBranch && deleteSeq != null && pos.dataSequenceNumber() >= deleteSeq) {
-        nonEligible.add(pos);
-      } else {
+      boolean specMatch = globalDelete || deleteSpecIds.contains(pos.specId());
+      boolean sequenceMatch =
+          !stagingOnTargetBranch || deleteSeq == null || pos.dataSequenceNumber() < deleteSeq;
+      if (specMatch && sequenceMatch) {
         out.collect(pos);
         count++;
+      } else {
+        nonEligible.add(pos);
       }
     }
 
@@ -270,5 +291,6 @@ public class EqualityConvertPKIndex
     bufferedRows.clear();
     resolveTimestamp.clear();
     resolveSequenceNumber.clear();
+    resolveSpecIds.clear();
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
@@ -151,7 +151,9 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
 
     int specId = file.specId();
     StructLike partition = file.partition();
-    Types.StructType partitionType = table.specs().get(specId).partitionType();
+    // Use the planner-serialized task spec, not the reader's table, which is loaded once and may
+    // lack specs added after startup.
+    Types.StructType partitionType = task.spec().partitionType();
     byte[] partitionBytes = fieldSerializer.encodePartition(partition, partitionType);
 
     InputFile input = table.io().newInputFile(file.location());
@@ -167,8 +169,7 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
           continue;
         }
 
-        SerializedEqualityValues key =
-            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        SerializedEqualityValues key = fieldSerializer.serializeKey(record, keySchema.asStruct());
         out.collect(
             IndexCommand.addDataRow(
                 mainSnapshotId,
@@ -194,17 +195,20 @@ public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCom
     ContentFile<?> file = task.file();
 
     int specId = file.specId();
+    // An unpartitioned equality delete applies globally; a partitioned one applies only within its
+    // own spec. Use the planner-serialized task spec, not the reader's table, which is loaded once
+    // and may lack specs added after startup.
+    int deleteSpecId = task.spec().isUnpartitioned() ? IndexCommand.GLOBAL_DELETE_SPEC_ID : specId;
 
     InputFile input = table.io().newInputFile(file.location());
     ReadBuilder<Record, Schema> builder =
         FormatModelRegistry.readBuilder(file.format(), Record.class, input);
     try (CloseableIterable<Record> records = builder.project(keySchema).reuseContainers().build()) {
       for (Record record : records) {
-        SerializedEqualityValues key =
-            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        SerializedEqualityValues key = fieldSerializer.serializeKey(record, keySchema.asStruct());
         out.collect(
             IndexCommand.resolveDelete(
-                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber));
+                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber, deleteSpecId));
       }
     }
   }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
@@ -40,6 +40,9 @@ import org.apache.flink.annotation.Internal;
  * <p>{@link #rowPosition} is the data row's location, set for the two add types and null otherwise;
  * the data sequence number it carries lets the worker apply a delete only to older rows. {@code
  * deleteSequenceNumber} is the equality delete's sequence number, set for {@link
+ * Type#RESOLVE_DELETE} and unused (-1) otherwise. {@code deleteSpecId} is the partition spec id of
+ * the delete file, used to scope a partitioned delete to data rows of the same spec; {@link
+ * #GLOBAL_DELETE_SPEC_ID} marks an unpartitioned delete that applies to every spec. Set for {@link
  * Type#RESOLVE_DELETE} and unused (-1) otherwise.
  */
 @Internal
@@ -49,8 +52,12 @@ public record IndexCommand(
     Long mainSequenceNumber,
     SerializedEqualityValues key,
     DVPosition rowPosition,
-    long deleteSequenceNumber)
+    long deleteSequenceNumber,
+    int deleteSpecId)
     implements Serializable {
+
+  /** Spec id sentinel for an unpartitioned equality delete, which applies as a global delete. */
+  public static final int GLOBAL_DELETE_SPEC_ID = -1;
 
   public enum Type {
     ADD_DATA_ROW,
@@ -75,6 +82,7 @@ public record IndexCommand(
         mainSequenceNumber,
         key,
         new DVPosition(filePath, position, specId, partition, dataSequenceNumber),
+        -1,
         -1);
   }
 
@@ -82,12 +90,20 @@ public record IndexCommand(
       Long mainSnapshotId,
       Long mainSequenceNumber,
       SerializedEqualityValues key,
-      long deleteSequenceNumber) {
+      long deleteSequenceNumber,
+      int deleteSpecId) {
     return new IndexCommand(
-        Type.RESOLVE_DELETE, mainSnapshotId, mainSequenceNumber, key, null, deleteSequenceNumber);
+        Type.RESOLVE_DELETE,
+        mainSnapshotId,
+        mainSequenceNumber,
+        key,
+        null,
+        deleteSequenceNumber,
+        deleteSpecId);
   }
 
   public static IndexCommand clearBeforeReindex(long mainSnapshotId, long mainSequenceNumber) {
-    return new IndexCommand(Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1);
+    return new IndexCommand(
+        Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1, -1);
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
@@ -36,8 +36,10 @@ import org.apache.iceberg.types.Types;
  * Serializer for {@link StructLike} tuples. Two entry points:
  *
  * <ul>
- *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues}),
- *       prefixed with the partition spec id so partition evolution keeps specs disjoint.
+ *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues})
+ *       from the equality values alone, so all rows with the same key co-locate on one shard
+ *       regardless of partition spec. Spec scoping of a delete is applied at resolve time, not in
+ *       the key.
  *   <li>{@link #encodePartition} / {@link #decodePartition} serialize partition tuples into bytes.
  * </ul>
  */
@@ -48,12 +50,9 @@ class StructLikeSerializer {
   private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
   private final DataOutputStream dos = new DataOutputStream(baos);
 
-  public SerializedEqualityValues serializeKey(
-      StructLike key, Types.StructType keyType, int specId) {
+  public SerializedEqualityValues serializeKey(StructLike key, Types.StructType keyType) {
     baos.reset();
     try {
-      dos.writeInt(specId);
-
       List<Types.NestedField> fields = keyType.fields();
       dos.writeInt(fields.size());
       for (Types.NestedField field : fields) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -238,7 +238,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
   @Override
   public PositionDeleteWriter<RowData> newPosDeleteWriter(
       EncryptedOutputFile outputFile, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete(table);
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
     try {
       switch (format) {
         case AVRO:

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletes.java
@@ -735,6 +735,62 @@ class TestConvertEqualityDeletes extends MaintenanceTaskTestBase {
   }
 
   @Test
+  void testUnpartitionedDeleteAppliesAcrossPartitionEvolution() throws Exception {
+    // Data is written under a partitioned spec, then the table evolves to unpartitioned. A delete
+    // written under the unpartitioned spec is a global delete and must remove the data row from the
+    // older spec. This only works because the index key is spec-independent (spec scoping happens
+    // at resolve time, where a global delete matches every spec).
+    Table table = createPartitionedTableWithDelete(3);
+    insertPartitioned(table, 1, "a");
+
+    table.updateSpec().removeField("data").commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // writeEqualityDelete writes with the current (now unpartitioned) spec, so the delete is
+    // global.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    assertRecords(table, ImmutableList.of());
+  }
+
+  @Test
+  void testPartitionedDeleteDoesNotApplyAcrossPartitionEvolution() throws Exception {
+    // Inverse of the global case: a partitioned delete under a new spec must NOT remove a data row
+    // written under an older spec. The row survives because resolution is scoped to the delete's
+    // spec.
+    Table table = createPartitionedTableWithDelete(3);
+    insertPartitioned(table, 1, "a");
+
+    // Evolve to a different partition spec so the delete below is written under a new spec id.
+    table.updateSpec().removeField("data").addField("id").commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeIdPartitionedEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    appendConvertTask();
+    runAndWaitForSuccess(infra.env(), infra.source(), infra.sink());
+
+    table.refresh();
+    // The spec-0 row survives: the delete's spec differs and it is not a global (unpartitioned)
+    // delete.
+    assertRecords(table, ImmutableList.of(createRecord(1, "a")));
+  }
+
+  @Test
   void testStagingPositionDeleteMergedIntoConversionDV() throws Exception {
     Table table = createTableWithDelete(3);
 
@@ -993,6 +1049,21 @@ class TestConvertEqualityDeletes extends MaintenanceTaskTestBase {
 
     PartitionData partition = new PartitionData(table.spec().partitionType());
     partition.set(0, data);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        partition,
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private DeleteFile writeIdPartitionedEqualityDelete(Table table, Integer id, String data)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PartitionData partition = new PartitionData(table.spec().partitionType());
+    partition.set(0, id);
     return FileHelpers.writeDeleteFile(
         table,
         Files.localOutput(file),

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
@@ -22,11 +22,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.KeyedBroadcastOperatorTestHarness;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestEqualityConvertPKIndex {
 
@@ -42,6 +46,8 @@ class TestEqualityConvertPKIndex {
   // Data-row sequence below the delete sequence, so existing tests still tombstone on resolve.
   private static final long DATA_SEQ = 1L;
   private static final long DELETE_SEQ = 2L;
+  // Default delete scope for the single-spec tests: global, so it resolves rows of any spec.
+  private static final int GLOBAL = IndexCommand.GLOBAL_DELETE_SPEC_ID;
 
   @Test
   void addDataRowProducesNoOutput() throws Exception {
@@ -90,7 +96,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -136,7 +142,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -154,6 +160,61 @@ class TestEqualityConvertPKIndex {
                 assertThat(pos.position()).isEqualTo(3);
               });
     }
+  }
+
+  @ParameterizedTest(name = "deleteSpecs={0} resolvedSpecs={1}")
+  @MethodSource("deleteSpecScopes")
+  void resolvesDeletesScopedBySpec(List<Integer> deleteSpecIds, List<Integer> resolvedSpecIds)
+      throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // Same key, one row under each of two specs. Partition evolution co-locates them on one
+      // shard.
+      harness.processElement(new StreamRecord<>(addRow("spec0.parquet", 0, 0), 0));
+      harness.processElement(new StreamRecord<>(addRow("spec1.parquet", 1, 1), 0));
+      // All deletes fall in one delete phase (ts 1), so their scopes accumulate.
+      for (int deleteSpecId : deleteSpecIds) {
+        harness.processElement(
+            new StreamRecord<>(
+                IndexCommand.resolveDelete(
+                    MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, deleteSpecId),
+                1));
+      }
+
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues())
+          .extracting(DVPosition::specId)
+          .containsExactlyInAnyOrderElementsOf(resolvedSpecIds);
+    }
+  }
+
+  private static Stream<Arguments> deleteSpecScopes() {
+    return Stream.of(
+        // A partitioned delete resolves only same-spec rows.
+        Arguments.of(List.of(1), List.of(1)),
+        // An unpartitioned (global) delete resolves rows of every spec.
+        Arguments.of(List.of(GLOBAL), List.of(0, 1)),
+        // Two partitioned deletes from different specs in one phase both apply.
+        Arguments.of(List.of(0, 1), List.of(0, 1)),
+        // A global delete scope affects a later partitioned delete in the same phase.
+        Arguments.of(List.of(GLOBAL, 0), List.of(0, 1)));
+  }
+
+  private static IndexCommand addRow(String filePath, long position, int specId) {
+    return IndexCommand.addDataRow(
+        MAIN_SNAPSHOT,
+        MAIN_SEQ,
+        KEY_1,
+        filePath,
+        position,
+        specId,
+        EMPTY_PARTITION,
+        DATA_SEQ,
+        false);
   }
 
   @Test
@@ -178,13 +239,13 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
       assertThat(harness.extractOutputValues()).hasSize(1);
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 2));
       harness.watermark(2);
       assertThat(harness.extractOutputValues()).hasSize(1);
     }
@@ -199,7 +260,7 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -229,7 +290,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              1));
       harness.watermark(1);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -266,7 +329,9 @@ class TestEqualityConvertPKIndex {
       // Resolving KEY_1 against the (now-empty) index emits nothing.
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              2));
       harness.watermark(2);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -299,7 +364,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              2));
       harness.watermark(2);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -350,7 +417,9 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+              IndexCommand.resolveDelete(
+                  NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL),
+              3));
       harness.watermark(3);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -383,7 +452,7 @@ class TestEqualityConvertPKIndex {
           new StreamRecord<>(IndexCommand.clearBeforeReindex(999L, 10L), 1));
 
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ), 2));
+          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ, GLOBAL), 2));
       harness.watermark(2);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -429,7 +498,7 @@ class TestEqualityConvertPKIndex {
 
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -463,7 +532,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.processElement(
           new StreamRecord<>(
               IndexCommand.addDataRow(
@@ -487,7 +556,7 @@ class TestEqualityConvertPKIndex {
       // A later cycle's delete (ts 3) removes the now-indexed new row.
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 3));
       harness.watermark(3);
       assertThat(harness.extractOutputValues()).hasSize(2);
       assertThat(harness.extractOutputValues().get(1).dataFilePath()).isEqualTo("new.parquet");
@@ -518,7 +587,7 @@ class TestEqualityConvertPKIndex {
               2));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
       harness.watermark(2);
 
       assertThat(harness.extractOutputValues()).isEmpty();
@@ -560,7 +629,7 @@ class TestEqualityConvertPKIndex {
               0));
       harness.processElement(
           new StreamRecord<>(
-              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ, GLOBAL), 1));
 
       harness.watermark(1);
 
@@ -601,7 +670,8 @@ class TestEqualityConvertPKIndex {
 
       // Delete at seq 2 tombstones only the older row; the re-insert (seq 3) survives.
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();
@@ -610,7 +680,8 @@ class TestEqualityConvertPKIndex {
 
       // The survivor stays indexed: a later delete with a higher sequence removes it.
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L), 2));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L, GLOBAL), 2));
       harness.watermark(2);
 
       List<DVPosition> afterSecond = harness.extractOutputValues();
@@ -644,7 +715,8 @@ class TestEqualityConvertPKIndex {
                   false),
               0));
       harness.processElement(
-          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L, GLOBAL), 1));
       harness.watermark(1);
 
       List<DVPosition> output = harness.extractOutputValues();

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
@@ -35,8 +35,6 @@ class TestStructLikeSerializer {
           Types.NestedField.required(1, "id", Types.IntegerType.get()),
           Types.NestedField.optional(2, "data", Types.StringType.get()));
 
-  private static final int SPEC_0 = PartitionSpec.unpartitioned().specId();
-
   private final StructLikeSerializer serializer = new StructLikeSerializer();
 
   @Test
@@ -45,8 +43,8 @@ class TestStructLikeSerializer {
     key.set(0, 42);
     key.set(1, "hello");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -60,8 +58,8 @@ class TestStructLikeSerializer {
     record2.set(0, 2);
     record2.set(1, "b");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE);
     assertThat(key1).isNotEqualTo(key2);
   }
 
@@ -78,8 +76,8 @@ class TestStructLikeSerializer {
     GenericRecord record3 = GenericRecord.create(typeWithField3);
     record3.set(0, 42);
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1);
+    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3);
     assertThat(key1).isNotEqualTo(key2);
   }
 
@@ -94,8 +92,8 @@ class TestStructLikeSerializer {
     record.set(0, new BigDecimal("123.45"));
     record.set(1, "test");
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -105,8 +103,8 @@ class TestStructLikeSerializer {
     record.set(0, 1);
     record.set(1, null);
 
-    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
-    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE);
     assertThat(key1).isEqualTo(key2);
   }
 
@@ -120,18 +118,8 @@ class TestStructLikeSerializer {
     withValue.set(0, 1);
     withValue.set(1, "");
 
-    assertThat(serializer.serializeKey(withNull, KEY_TYPE, SPEC_0))
-        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE, SPEC_0));
-  }
-
-  @Test
-  void samePkDifferentSpecsAreNotEqual() {
-    GenericRecord pk = GenericRecord.create(KEY_TYPE);
-    pk.set(0, 42);
-    pk.set(1, "x");
-
-    assertThat(serializer.serializeKey(pk, KEY_TYPE, 0))
-        .isNotEqualTo(serializer.serializeKey(pk, KEY_TYPE, 1));
+    assertThat(serializer.serializeKey(withNull, KEY_TYPE))
+        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE));
   }
 
   @Test

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -64,9 +64,4 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected void checkRowStatistics(Map<Integer, ByteBuffer> bounds) {
     assertThat(bounds).hasSize(2);
   }
-
-  @Override
-  protected void checkNotExistingRowStatistics(Map<Integer, ByteBuffer> bounds) {
-    assertThat(bounds).isNull();
-  }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkAppenderFactory.java
@@ -238,7 +238,7 @@ public class FlinkAppenderFactory implements FileAppenderFactory<RowData>, Seria
   @Override
   public PositionDeleteWriter<RowData> newPosDeleteWriter(
       EncryptedOutputFile outputFile, FileFormat format, StructLike partition) {
-    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete(table);
+    MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
     try {
       switch (format) {
         case AVRO:

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
@@ -447,7 +447,7 @@ class TestFlinkVariantShreddingType extends CatalogTestBase {
             "value",
             shreddedPrimitive(
                 PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-                16,
+                9, // decimalRequiredBytes(21)
                 LogicalTypeAnnotation.decimalType(6, 21)));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
     MessageType expectedSchema = parquetSchema(address);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestFlinkWriterMetrics.java
@@ -64,9 +64,4 @@ public class TestFlinkWriterMetrics extends TestWriterMetrics<RowData> {
   protected void checkRowStatistics(Map<Integer, ByteBuffer> bounds) {
     assertThat(bounds).hasSize(2);
   }
-
-  @Override
-  protected void checkNotExistingRowStatistics(Map<Integer, ByteBuffer> bounds) {
-    assertThat(bounds).isNull();
-  }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.util.NaNUtil;
 import org.apache.iceberg.util.UnicodeUtil;
 import org.apache.iceberg.variants.PhysicalType;
 import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
@@ -66,43 +67,64 @@ import org.apache.parquet.schema.Type;
 class ParquetMetrics {
   private ParquetMetrics() {}
 
-  static Metrics metrics(
+  static Iterable<FieldMetrics<?>> fieldMetrics(
       Schema schema,
       MessageType type,
       MetricsConfig metricsConfig,
       ParquetMetadata metadata,
       Stream<FieldMetrics<?>> fields) {
-    long rowCount = 0L;
-    Map<Integer, Long> columnSizes = Maps.newHashMap();
     Multimap<ColumnPath, ColumnChunkMetaData> columns =
         Multimaps.newMultimap(Maps.newHashMap(), Lists::newArrayList);
     for (BlockMetaData block : metadata.getBlocks()) {
-      rowCount += block.getRowCount();
       for (ColumnChunkMetaData column : block.getColumns()) {
         columns.put(column.getPath(), column);
-
-        Type.ID id =
-            type.getColumnDescription(column.getPath().toArray()).getPrimitiveType().getId();
-        if (null == id) {
-          continue;
-        }
-
-        int fieldId = id.intValue();
-        MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
-        if (mode != MetricsModes.None.get()) {
-          columnSizes.put(fieldId, columnSizes.getOrDefault(fieldId, 0L) + column.getTotalSize());
-        }
       }
     }
 
     Map<Integer, FieldMetrics<?>> metricsById =
         fields.collect(Collectors.toMap(FieldMetrics::id, Function.identity()));
 
-    Iterable<FieldMetrics<ByteBuffer>> results =
-        TypeWithSchemaVisitor.visit(
-            schema.asStruct(),
-            type,
-            new MetricsVisitor(schema, metricsConfig, metricsById, columns));
+    return TypeWithSchemaVisitor.visit(
+        schema.asStruct(), type, new MetricsVisitor(schema, metricsConfig, metricsById, columns));
+  }
+
+  private static long rowCount(ParquetMetadata metadata) {
+    long rowCount = 0L;
+    for (BlockMetaData block : metadata.getBlocks()) {
+      rowCount += block.getRowCount();
+    }
+
+    return rowCount;
+  }
+
+  private static Map<Integer, Long> columnSizes(
+      Schema schema, MessageType type, ParquetMetadata metadata, MetricsConfig metricsConfig) {
+    Map<Integer, Long> columnSizes = Maps.newHashMap();
+    for (BlockMetaData block : metadata.getBlocks()) {
+      for (ColumnChunkMetaData column : block.getColumns()) {
+        Type.ID id =
+            type.getColumnDescription(column.getPath().toArray()).getPrimitiveType().getId();
+        if (id != null) {
+          int fieldId = id.intValue();
+          MetricsModes.MetricsMode mode = MetricsUtil.metricsMode(schema, metricsConfig, fieldId);
+          if (mode != MetricsModes.None.get()) {
+            columnSizes.put(fieldId, columnSizes.getOrDefault(fieldId, 0L) + column.getTotalSize());
+          }
+        }
+      }
+    }
+
+    return columnSizes;
+  }
+
+  static Metrics metrics(
+      Schema schema,
+      MessageType type,
+      MetricsConfig metricsConfig,
+      ParquetMetadata metadata,
+      Stream<FieldMetrics<?>> fields) {
+    long rowCount = rowCount(metadata);
+    Map<Integer, Long> columnSizes = columnSizes(schema, type, metadata, metricsConfig);
 
     Map<Integer, Long> valueCounts = Maps.newHashMap();
     Map<Integer, Long> nullValueCounts = Maps.newHashMap();
@@ -111,7 +133,7 @@ class ParquetMetrics {
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
     Map<Integer, org.apache.iceberg.types.Type> originalTypes = Maps.newHashMap();
 
-    for (FieldMetrics<ByteBuffer> metrics : results) {
+    for (FieldMetrics<?> metrics : fieldMetrics(schema, type, metricsConfig, metadata, fields)) {
       int id = metrics.id();
       if (null != metrics.originalType()) {
         originalTypes.put(id, metrics.originalType());
@@ -130,11 +152,15 @@ class ParquetMetrics {
       }
 
       if (metrics.lowerBound() != null) {
-        lowerBounds.put(id, metrics.lowerBound());
+        ByteBuffer lowerBound =
+            Conversions.toByteBuffer(metrics.originalType(), metrics.lowerBound());
+        lowerBounds.put(id, lowerBound);
       }
 
       if (metrics.upperBound() != null) {
-        upperBounds.put(id, metrics.upperBound());
+        ByteBuffer upperBound =
+            Conversions.toByteBuffer(metrics.originalType(), metrics.upperBound());
+        upperBounds.put(id, upperBound);
       }
     }
 
@@ -149,8 +175,7 @@ class ParquetMetrics {
         originalTypes);
   }
 
-  private static class MetricsVisitor
-      extends TypeWithSchemaVisitor<Iterable<FieldMetrics<ByteBuffer>>> {
+  private static class MetricsVisitor extends TypeWithSchemaVisitor<Iterable<FieldMetrics<?>>> {
     private final Schema schema;
     private final MetricsConfig metricsConfig;
     private final Map<Integer, FieldMetrics<?>> metricsById;
@@ -168,40 +193,38 @@ class ParquetMetrics {
     }
 
     @Override
-    public Iterable<FieldMetrics<ByteBuffer>> message(
+    public Iterable<FieldMetrics<?>> message(
         Types.StructType iStruct,
         MessageType message,
-        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+        List<Iterable<FieldMetrics<?>>> fieldResults) {
       return Iterables.concat(fieldResults);
     }
 
     @Override
-    public Iterable<FieldMetrics<ByteBuffer>> struct(
-        Types.StructType iStruct,
-        GroupType struct,
-        List<Iterable<FieldMetrics<ByteBuffer>>> fieldResults) {
+    public Iterable<FieldMetrics<?>> struct(
+        Types.StructType iStruct, GroupType struct, List<Iterable<FieldMetrics<?>>> fieldResults) {
       return Iterables.concat(fieldResults);
     }
 
     @Override
-    public Iterable<FieldMetrics<ByteBuffer>> list(
-        Types.ListType iList, GroupType array, Iterable<FieldMetrics<ByteBuffer>> elementResults) {
+    public Iterable<FieldMetrics<?>> list(
+        Types.ListType iList, GroupType array, Iterable<FieldMetrics<?>> elementResults) {
       // remove lower and upper bounds for repeated fields
       return ImmutableList.of();
     }
 
     @Override
-    public Iterable<FieldMetrics<ByteBuffer>> map(
+    public Iterable<FieldMetrics<?>> map(
         Types.MapType iMap,
         GroupType map,
-        Iterable<FieldMetrics<ByteBuffer>> keyResults,
-        Iterable<FieldMetrics<ByteBuffer>> valueResults) {
+        Iterable<FieldMetrics<?>> keyResults,
+        Iterable<FieldMetrics<?>> valueResults) {
       // repeated fields are not currently supported
       return ImmutableList.of();
     }
 
     @Override
-    public Iterable<FieldMetrics<ByteBuffer>> primitive(
+    public Iterable<FieldMetrics<?>> primitive(
         org.apache.iceberg.types.Type.PrimitiveType iPrimitive, PrimitiveType primitive) {
       Type.ID id = primitive.getId();
       if (null == id) {
@@ -216,7 +239,8 @@ class ParquetMetrics {
 
       int length = truncateLength(mode);
 
-      FieldMetrics<ByteBuffer> metrics = metricsFromFieldMetrics(fieldId, iPrimitive, length);
+      FieldMetrics<?> metrics =
+          metricsFromFieldMetrics(metricsById.get(fieldId), iPrimitive, length);
       if (metrics != null) {
         return ImmutableList.of(metrics);
       }
@@ -229,9 +253,10 @@ class ParquetMetrics {
       return ImmutableList.of();
     }
 
-    private FieldMetrics<ByteBuffer> metricsFromFieldMetrics(
-        int fieldId, org.apache.iceberg.types.Type.PrimitiveType icebergType, int truncateLength) {
-      FieldMetrics<?> fieldMetrics = metricsById.get(fieldId);
+    private <T> FieldMetrics<T> metricsFromFieldMetrics(
+        FieldMetrics<T> fieldMetrics,
+        org.apache.iceberg.types.Type.PrimitiveType icebergType,
+        int truncateLength) {
       if (null == fieldMetrics) {
         return null;
       } else if (truncateLength <= 0) {
@@ -241,24 +266,20 @@ class ParquetMetrics {
             fieldMetrics.nullValueCount(),
             fieldMetrics.nanValueCount());
       } else {
-        Object lowerBound =
-            truncateLowerBound(icebergType, fieldMetrics.lowerBound(), truncateLength);
-        Object upperBound =
-            truncateUpperBound(icebergType, fieldMetrics.upperBound(), truncateLength);
-        ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
-        ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
+        T lowerBound = truncateLowerBound(icebergType, fieldMetrics.lowerBound(), truncateLength);
+        T upperBound = truncateUpperBound(icebergType, fieldMetrics.upperBound(), truncateLength);
         return new FieldMetrics<>(
             fieldMetrics.id(),
             fieldMetrics.valueCount(),
             fieldMetrics.nullValueCount(),
             fieldMetrics.nanValueCount(),
-            lower,
-            upper,
+            lowerBound,
+            upperBound,
             icebergType);
       }
     }
 
-    private FieldMetrics<ByteBuffer> metricsFromFooter(
+    private <T> FieldMetrics<T> metricsFromFooter(
         int fieldId,
         org.apache.iceberg.types.Type.PrimitiveType icebergType,
         PrimitiveType primitive,
@@ -278,7 +299,7 @@ class ParquetMetrics {
       return typeId == TypeID.GEOMETRY || typeId == TypeID.GEOGRAPHY;
     }
 
-    private FieldMetrics<ByteBuffer> counts(int fieldId) {
+    private <T> FieldMetrics<T> counts(int fieldId) {
       ColumnPath path = ColumnPath.get(currentPath());
       long valueCount = 0;
       long nullCount = 0;
@@ -296,7 +317,7 @@ class ParquetMetrics {
       return new FieldMetrics<>(fieldId, valueCount, nullCount);
     }
 
-    private <T> FieldMetrics<ByteBuffer> bounds(
+    private <T> FieldMetrics<T> bounds(
         int fieldId,
         org.apache.iceberg.types.Type.PrimitiveType icebergType,
         PrimitiveType primitive,
@@ -343,16 +364,14 @@ class ParquetMetrics {
       lowerBound = truncateLowerBound(icebergType, lowerBound, truncateLength);
       upperBound = truncateUpperBound(icebergType, upperBound, truncateLength);
 
-      ByteBuffer lower = Conversions.toByteBuffer(icebergType, lowerBound);
-      ByteBuffer upper = Conversions.toByteBuffer(icebergType, upperBound);
-
-      return new FieldMetrics<>(fieldId, valueCount, nullCount, lower, upper, icebergType);
+      return new FieldMetrics<>(
+          fieldId, valueCount, nullCount, lowerBound, upperBound, icebergType);
     }
 
     @Override
     @SuppressWarnings("CyclomaticComplexity")
-    public Iterable<FieldMetrics<ByteBuffer>> variant(
-        Types.VariantType iVariant, GroupType variant, Iterable<FieldMetrics<ByteBuffer>> ignored) {
+    public Iterable<FieldMetrics<?>> variant(
+        Types.VariantType iVariant, GroupType variant, Iterable<FieldMetrics<?>> ignored) {
       Type.ID id = variant.getId();
       if (null == id) {
         return ImmutableList.of();
@@ -409,8 +428,8 @@ class ParquetMetrics {
               fieldId,
               metadataCounts.valueCount(),
               metadataCounts.nullCount(),
-              ParquetVariantUtil.toByteBuffer(metadata, lowerBounds),
-              ParquetVariantUtil.toByteBuffer(metadata, upperBounds),
+              Variant.of(metadata, lowerBounds),
+              Variant.of(metadata, upperBounds),
               Types.VariantType.get()));
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.variants.PhysicalType;
 import org.apache.iceberg.variants.VariantArray;
@@ -347,7 +348,7 @@ public abstract class VariantShreddingAnalyzer<T, S> {
           .named(TYPED_VALUE);
     } else {
       return Types.optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-          .length(16)
+          .length(TypeUtil.decimalRequiredBytes(maxPrecision))
           .as(LogicalTypeAnnotation.decimalType(maxScale, maxPrecision))
           .named(TYPED_VALUE);
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantShreddingAnalyzer.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantShreddingAnalyzer.java
@@ -21,11 +21,13 @@ package org.apache.iceberg.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.VariantMetadata;
@@ -36,6 +38,8 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestVariantShreddingAnalyzer {
 
@@ -249,6 +253,35 @@ public class TestVariantShreddingAnalyzer {
         .isEqualTo(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }
 
+  @ParameterizedTest
+  @CsvSource({"20, 9", "28, 12", "33, 14"})
+  public void testDecimalExceedingPrecisionUsesMinimumFixedLength(
+      int precision, int expectedLength) {
+    DirectAnalyzer analyzer = new DirectAnalyzer();
+
+    // Precision > 18 shreds to FIXED_LEN_BYTE_ARRAY; the declared length must equal what the
+    // writer emits (decimalRequiredBytes).
+    VariantMetadata meta = Variants.metadata("val");
+    ShreddedObject row = Variants.object(meta);
+    row.put("val", Variants.of(new BigDecimal(BigInteger.TEN.pow(precision - 1))));
+
+    Type schema = analyzer.analyzeAndCreateSchema(List.of(row), 0);
+    assertThat(schema).isNotNull();
+
+    GroupType valGroup = schema.asGroupType().getType("val").asGroupType();
+    PrimitiveType valPrimitive = valGroup.getType("typed_value").asPrimitiveType();
+
+    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal =
+        (LogicalTypeAnnotation.DecimalLogicalTypeAnnotation)
+            valPrimitive.getLogicalTypeAnnotation();
+    assertThat(decimal.getPrecision()).isEqualTo(precision);
+    assertThat(valPrimitive.getPrimitiveTypeName())
+        .isEqualTo(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+    assertThat(valPrimitive.getTypeLength())
+        .isEqualTo(expectedLength)
+        .isEqualTo(TypeUtil.decimalRequiredBytes(precision));
+  }
+
   @Test
   public void testDecimalForExactPrecision() {
     DirectAnalyzer analyzer = new DirectAnalyzer();
@@ -270,6 +303,10 @@ public class TestVariantShreddingAnalyzer {
             valPrimitive.getLogicalTypeAnnotation();
     assertThat(decimal.getPrecision()).isEqualTo(38);
     assertThat(decimal.getScale()).isEqualTo(18);
+    // Precision 38 is the max and requires the full 16-byte FIXED width.
+    assertThat(valPrimitive.getTypeLength())
+        .isEqualTo(TypeUtil.decimalRequiredBytes(38))
+        .isEqualTo(16);
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -215,6 +215,34 @@ public class TestVariantWriters {
     InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
   }
 
+  @Test
+  public void testShreddedDecimal16RoundTripUsesWriterCompatibleFixedLength() throws IOException {
+    // A DECIMAL16 value (20-digit integer) shreds to a FIXED_LEN_BYTE_ARRAY typed_value whose
+    // declared length must equal decimalRequiredBytes, or the write fails. toParquetSchema shreds
+    // DECIMAL16 as BINARY, so this fixed-length path is otherwise untested.
+    VariantValue value = Variants.of(new BigDecimal("12345678901234567890"));
+    Variant variant = Variant.of(EMPTY_METADATA, value);
+    Record record = RECORD.copy("id", 1, "var", variant);
+
+    VariantShreddingAnalyzer<VariantValue, Void> analyzer =
+        new VariantShreddingAnalyzer<>() {
+          @Override
+          protected List<VariantValue> extractVariantValues(List<VariantValue> rows, int idx) {
+            return rows;
+          }
+
+          @Override
+          protected int resolveColumnIndex(Void engineSchema, String columnName) {
+            throw new UnsupportedOperationException("Not used in this test");
+          }
+        };
+
+    Record actual =
+        writeAndRead((id, name) -> analyzer.analyzeAndCreateSchema(List.of(value), 0), record);
+
+    InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
+  }
+
   @ParameterizedTest
   @FieldSource("VARIANTS")
   public void testMixedShredding(Variant variant) throws IOException {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
@@ -166,10 +166,7 @@ class SparkFileWriterFactory extends RegistryBasedFileWriterFactory<InternalRow,
     } else {
       LOG.warn("Position deletes with deleted rows are deprecated and will be removed in 1.12.0.");
       Map<String, String> properties = table == null ? ImmutableMap.of() : table.properties();
-      MetricsConfig metricsConfig =
-          table == null
-              ? MetricsConfig.forPositionDelete()
-              : MetricsConfig.forPositionDelete(table);
+      MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
       try {
         return switch (deleteFormat) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -65,7 +65,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))
@@ -90,7 +90,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
@@ -166,10 +166,7 @@ class SparkFileWriterFactory extends RegistryBasedFileWriterFactory<InternalRow,
     } else {
       LOG.warn("Position deletes with deleted rows are deprecated and will be removed in 1.12.0.");
       Map<String, String> properties = table == null ? ImmutableMap.of() : table.properties();
-      MetricsConfig metricsConfig =
-          table == null
-              ? MetricsConfig.forPositionDelete()
-              : MetricsConfig.forPositionDelete(table);
+      MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
       try {
         return switch (deleteFormat) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -65,7 +65,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))
@@ -90,7 +90,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
@@ -554,7 +554,7 @@ public class TestVariantShredding extends CatalogTestBase {
         field(
             "value",
             optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-                .length(16)
+                .length(9) // decimalRequiredBytes(21)
                 .as(LogicalTypeAnnotation.decimalType(6, 21))
                 .named("typed_value"));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
@@ -992,6 +992,24 @@ public class TestVariantShredding extends CatalogTestBase {
     assertThat(rows.get(3)[1]).isEqualTo(new BigDecimal("123456.7800"));
     assertThat(rows.get(4)[1]).isEqualTo(new BigDecimal("1.2345"));
     assertThat(rows.get(5)[1]).isEqualTo(new BigDecimal("12.3000"));
+  }
+
+  @TestTemplate
+  public void testShreddedLargeIntegerVariantReadBack() {
+    // DECIMAL16 (20-digit integer, above Long.MAX_VALUE) shreds to a FIXED_LEN_BYTE_ARRAY
+    // typed_value whose declared length must equal what FixedDecimalWriter emits.
+    spark.conf().set(SparkSQLProperties.SHRED_VARIANTS, "true");
+
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"v\":12345678901234567890}')), "
+            + "(2, parse_json('{\"v\":-12345678901234567890}'))",
+        tableName);
+
+    List<Object[]> values =
+        sql("SELECT variant_get(address, '$.v', 'decimal(38,0)') FROM %s ORDER BY id", tableName);
+    assertThat(values.get(0)[0]).isEqualTo(new BigDecimal("12345678901234567890"));
+    assertThat(values.get(1)[0]).isEqualTo(new BigDecimal("-12345678901234567890"));
   }
 
   private void verifyParquetSchema(Table table, MessageType expectedSchema) throws IOException {

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -119,12 +119,8 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
       OrderAwareCoalesceExec(numPartitions, coalescer, planLater(child)) :: Nil
 
     case RenameTable(ResolvedV2View(oldCatalog: ViewCatalog, oldIdent), newName, isView @ true) =>
-      val newIdent = Spark3Util.catalogAndIdentifier(spark, newName.toList.asJava)
-      if (oldCatalog.name != newIdent.catalog().name()) {
-        throw new IcebergAnalysisException(
-          s"Cannot move view between catalogs: from=${oldCatalog.name} and to=${newIdent.catalog().name()}")
-      }
-      RenameV2ViewExec(oldCatalog, oldIdent, newIdent.identifier()) :: Nil
+      val targetIdent = resolveViewRenameTarget(oldCatalog, newName)
+      RenameV2ViewExec(oldCatalog, oldIdent, targetIdent) :: Nil
 
     case DropIcebergView(ResolvedIdentifier(viewCatalog: ViewCatalog, ident), ifExists) =>
       DropV2ViewExec(viewCatalog, ident, ifExists) :: Nil
@@ -174,6 +170,22 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
       AlterV2ViewUnsetPropertiesExec(catalog, ident, propertyKeys, ifExists) :: Nil
 
     case _ => Nil
+  }
+
+  private def resolveViewRenameTarget(
+      sourceCatalog: ViewCatalog,
+      targetName: Seq[String]): Identifier = {
+    if (targetName.length == 1) {
+      Identifier.of(Array.empty[String], targetName.head)
+    } else {
+      val target = Spark3Util.catalogAndIdentifier(spark, targetName.toList.asJava, sourceCatalog)
+      if (sourceCatalog.name != target.catalog().name()) {
+        throw new IcebergAnalysisException(
+          s"Cannot move view between catalogs: from=${sourceCatalog.name} and to=${target.catalog().name()}")
+      }
+
+      target.identifier()
+    }
   }
 
   private object IcebergCatalogAndIdentifier {

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameV2ViewExec.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameV2ViewExec.scala
@@ -29,7 +29,14 @@ case class RenameV2ViewExec(catalog: ViewCatalog, oldIdent: Identifier, newIdent
   override lazy val output: Seq[Attribute] = Nil
 
   override protected def run(): Seq[InternalRow] = {
-    catalog.renameView(oldIdent, newIdent)
+    // Match Spark's v2 rename behavior: an unqualified target renames in place.
+    val qualifiedNewIdent =
+      if (newIdent.namespace().isEmpty) {
+        Identifier.of(oldIdent.namespace(), newIdent.name())
+      } else {
+        newIdent
+      }
+    catalog.renameView(oldIdent, qualifiedNewIdent)
 
     Seq.empty
   }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -775,6 +775,34 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void renameQualifiedViewToUnqualifiedTargetKeepsSourceNamespace() {
+    Namespace sourceNamespace = Namespace.of(viewName("rename_source_ns"));
+    Namespace currentNamespace = Namespace.of(viewName("rename_current_ns"));
+    String viewName = viewName("originalView");
+    String renamedView = viewName("renamedView");
+    String sql = String.format("SELECT id FROM %s.%s.%s", catalogName, NAMESPACE, tableName);
+
+    sql("CREATE NAMESPACE IF NOT EXISTS %s.%s", catalogName, sourceNamespace);
+    sql("CREATE NAMESPACE IF NOT EXISTS %s.%s", catalogName, currentNamespace);
+
+    ViewCatalog viewCatalog = viewCatalog();
+    viewCatalog
+        .buildView(TableIdentifier.of(sourceNamespace, viewName))
+        .withQuery("spark", sql)
+        .withDefaultNamespace(sourceNamespace)
+        .withDefaultCatalog(catalogName)
+        .withSchema(schema(sql))
+        .create();
+
+    sql("USE %s.%s", catalogName, currentNamespace);
+    sql("ALTER VIEW %s.%s RENAME TO %s", sourceNamespace, viewName, renamedView);
+
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(sourceNamespace, viewName))).isFalse();
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(sourceNamespace, renamedView))).isTrue();
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(currentNamespace, renamedView))).isFalse();
+  }
+
+  @TestTemplate
   public void renameViewHiddenByTempView() throws NoSuchTableException {
     insertRows(10);
     String viewName = viewName("originalView");

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.variants.Variant;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -63,8 +64,10 @@ import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.GeographyVal;
 import org.apache.spark.unsafe.types.GeometryVal;
@@ -243,6 +246,14 @@ public class SparkParquetReaders {
     public ParquetValueReader<?> primitive(
         org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
+
+      LogicalTypeAnnotation logicalType = primitive.getLogicalTypeAnnotation();
+      if (logicalType instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) {
+        String crs = ((LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) logicalType).getCrs();
+        return new GeometryReader(desc, sridFromCrs(crs));
+      } else if (logicalType instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) {
+        return new GeographyReader(desc);
+      }
 
       if (primitive.getOriginalType() != null) {
         switch (primitive.getOriginalType()) {
@@ -534,6 +545,44 @@ public class SparkParquetReaders {
       variant.value().writeTo(valueBuffer, 0);
 
       return new VariantVal(valueBytes, metadataBytes);
+    }
+  }
+
+  /** Resolves the Spark SRID for a geometry column's CRS (absent CRS defaults to OGC:CRS84). */
+  private static int sridFromCrs(String crs) {
+    if (crs == null) {
+      return GeometryType$.MODULE$.GEOMETRY_DEFAULT_SRID();
+    }
+    return GeometryType$.MODULE$.apply(crs).srid();
+  }
+
+  /** Reads a WKB BINARY column into a Spark {@link GeometryVal}. */
+  private static class GeometryReader extends PrimitiveReader<GeometryVal> {
+    private final int srid;
+
+    GeometryReader(ColumnDescriptor desc, int srid) {
+      super(desc);
+      this.srid = srid;
+    }
+
+    @Override
+    public GeometryVal read(GeometryVal ignored) {
+      // Iceberg stores pure WKB; Spark's GeometryVal is [SRID | WKB], so attach the column's SRID.
+      return STUtils.stGeomFromWKB(column.nextBinary().getBytes(), srid);
+    }
+  }
+
+  /** Reads a WKB BINARY column into a Spark {@link GeographyVal}. */
+  private static class GeographyReader extends PrimitiveReader<GeographyVal> {
+    GeographyReader(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public GeographyVal read(GeographyVal ignored) {
+      // Iceberg stores pure WKB; Spark's GeographyVal is [SRID | WKB]. Geography supports only
+      // OGC:CRS84, so the default SRID applies.
+      return STUtils.stGeogFromWKB(column.nextBinary().getBytes());
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -61,6 +61,7 @@ import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
@@ -71,6 +72,8 @@ import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
@@ -278,6 +281,18 @@ public class SparkParquetWriters {
           LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonLogicalType) {
         return Optional.of(byteArrays(desc));
       }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+        return Optional.of(new GeometryWriter(desc));
+      }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+        return Optional.of(new GeographyWriter(desc));
+      }
     }
 
     @Override
@@ -470,6 +485,32 @@ public class SparkParquetWriters {
     @Override
     public void write(int repetitionLevel, byte[] bytes) {
       column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(bytes));
+    }
+  }
+
+  /** Writes a Spark {@link GeometryVal} as its WKB bytes into a BINARY column. */
+  private static class GeometryWriter extends PrimitiveWriter<GeometryVal> {
+    private GeometryWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeometryVal value) {
+      // Spark stores geometry as [SRID | WKB]; Iceberg stores pure WKB, so strip the SRID header.
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(STUtils.stAsBinary(value)));
+    }
+  }
+
+  /** Writes a Spark {@link GeographyVal} as its WKB bytes into a BINARY column. */
+  private static class GeographyWriter extends PrimitiveWriter<GeographyVal> {
+    private GeographyWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeographyVal value) {
+      // Spark stores geography as [SRID | WKB]; Iceberg stores pure WKB, so strip the SRID header.
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(STUtils.stAsBinary(value)));
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkFileWriterFactory.java
@@ -166,10 +166,7 @@ class SparkFileWriterFactory extends RegistryBasedFileWriterFactory<InternalRow,
     } else {
       LOG.warn("Position deletes with deleted rows are deprecated and will be removed in 1.12.0.");
       Map<String, String> properties = table == null ? ImmutableMap.of() : table.properties();
-      MetricsConfig metricsConfig =
-          table == null
-              ? MetricsConfig.forPositionDelete()
-              : MetricsConfig.forPositionDelete(table);
+      MetricsConfig metricsConfig = MetricsConfig.forPositionDelete();
 
       try {
         return switch (deleteFormat) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkTableUtil.java
@@ -65,7 +65,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = KryoHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))
@@ -90,7 +90,7 @@ public class TestSparkTableUtil {
             TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "col2",
             "truncate(16)");
 
-    MetricsConfig config = MetricsConfig.fromProperties(metricsConfig);
+    MetricsConfig config = MetricsConfig.from(metricsConfig, null, null);
     MetricsConfig deserialized = TestHelpers.roundTripSerialize(config);
 
     assertThat(deserialized.columnMode("col1"))

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -54,8 +54,11 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 import scala.collection.Seq;
@@ -231,6 +234,18 @@ public class GenericsHelpers {
         assertThat(expected).as("Should expect a Variant").isInstanceOf(Variant.class);
         assertThat(actual).as("Should be a VariantVal").isInstanceOf(VariantVal.class);
         assertEquals((Variant) expected, (VariantVal) actual);
+        break;
+      case GEOMETRY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
+        assertThat(STUtils.stAsBinary((GeometryVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
+        break;
+      case GEOGRAPHY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
+        assertThat(STUtils.stAsBinary((GeographyVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:
@@ -432,6 +447,18 @@ public class GenericsHelpers {
         assertThat(expected).as("Should expect a Variant").isInstanceOf(Variant.class);
         assertThat(actual).as("Should be a VariantVal").isInstanceOf(VariantVal.class);
         assertEquals((Variant) expected, (VariantVal) actual);
+        break;
+      case GEOMETRY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
+        assertThat(STUtils.stAsBinary((GeometryVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
+        break;
+      case GEOGRAPHY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
+        assertThat(STUtils.stAsBinary((GeographyVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -47,6 +47,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
@@ -371,6 +372,11 @@ public class RandomData {
           return Decimal.apply((BigDecimal) obj);
         case UUID:
           return UTF8String.fromString(UUID.nameUUIDFromBytes((byte[]) obj).toString());
+        case GEOMETRY:
+          // Spark's GeometryVal is [SRID | WKB]; build it from the generated WKB.
+          return STUtils.stGeomFromWKB((byte[]) obj);
+        case GEOGRAPHY:
+          return STUtils.stGeogFromWKB((byte[]) obj);
         default:
           return obj;
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -118,6 +118,11 @@ public class TestSparkParquetReader extends AvroDataTestBase {
     return true;
   }
 
+  @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
   protected List<InternalRow> rowsFromFile(InputFile inputFile, Schema schema) throws IOException {
     try (CloseableIterable<InternalRow> reader =
         Parquet.read(inputFile)

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 import java.util.OptionalLong;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -37,12 +38,15 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -128,6 +132,53 @@ public class TestSparkParquetWriter {
         TestHelpers.assertEquals(COMPLEX_SCHEMA, expected.next(), rows.next());
       }
       assertThat(rows).as("Should not have extra rows").isExhausted();
+    }
+  }
+
+  @Test
+  public void testGeospatialWkbRoundTrip() throws IOException {
+    Schema geoSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "geom", Types.GeometryType.crs84()),
+            optional(3, "geog", Types.GeographyType.crs84()));
+
+    byte[] geomWkb = new byte[] {0x01, 0x02, 0x03};
+    byte[] geogWkb = new byte[] {0x04, 0x05, 0x06};
+    InternalRow row = new GenericInternalRow(3);
+    row.update(0, 1L);
+    // Spark's GeometryVal/GeographyVal wrap [SRID | WKB]; build them from the pure WKB.
+    row.update(1, STUtils.stGeomFromWKB(geomWkb));
+    row.update(2, STUtils.stGeogFromWKB(geogWkb));
+    // second row leaves the geo columns null
+    InternalRow nulls = new GenericInternalRow(3);
+    nulls.update(0, 2L);
+
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
+
+    try (FileAppender<InternalRow> writer =
+        Parquet.write(Files.localOutput(testFile))
+            .schema(geoSchema)
+            .createWriterFunc(
+                msgType ->
+                    SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(geoSchema), msgType))
+            .build()) {
+      writer.add(row);
+      writer.add(nulls);
+    }
+
+    try (CloseableIterable<InternalRow> reader =
+        Parquet.read(Files.localInput(testFile))
+            .project(geoSchema)
+            .createReaderFunc(type -> SparkParquetReaders.buildReader(geoSchema, type))
+            .build()) {
+      List<InternalRow> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(2);
+      assertThat(STUtils.stAsBinary(rows.get(0).getGeometry(1))).isEqualTo(geomWkb);
+      assertThat(STUtils.stAsBinary(rows.get(0).getGeography(2))).isEqualTo(geogWkb);
+      assertThat(rows.get(1).isNullAt(1)).isTrue();
+      assertThat(rows.get(1).isNullAt(2)).isTrue();
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestSparkGeospatial extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String TABLE = CATALOG + ".default.geo";
+
+  // WKB (little-endian) for POINT(30 10) and POINT(-71 42).
+  private static final String GEOM_WKB = "01010000000000000000003e400000000000002440";
+  private static final String GEOG_WKB = "01010000000000000000c051c00000000000004540";
+
+  @BeforeAll
+  public static void setupCatalog() {
+    // Use a Hadoop catalog to avoid Hive schema conversion (Hive doesn't support geo yet), and
+    // enable the geospatial feature, which Spark keeps behind a flag.
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    String warehouse = System.getProperty("java.io.tmpdir") + "/iceberg_spark_geo_warehouse";
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", warehouse);
+    spark.conf().set("spark.sql.geospatial.enabled", "true");
+  }
+
+  @BeforeEach
+  public void setupTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    // A bare GEOMETRY column is mixed-SRID, which Iceberg does not support, so the column SRID is
+    // pinned to 4326 (OGC:CRS84).
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        TABLE);
+
+    // st_geomfromwkb yields SRID 0, so set it to the column's SRID for the write to be accepted.
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, NULL, NULL)",
+        TABLE, GEOM_WKB, GEOG_WKB);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testGeospatialWkbReadBack(boolean vectorized) {
+    assumeThat(vectorized).as("Geo vectorized Parquet read is not implemented yet").isFalse();
+    setVectorization(vectorized);
+
+    // st_asbinary strips the SRID header back to pure WKB, matching what was inserted.
+    assertEquals(
+        "Geometry and geography WKB should round-trip through a Spark scan",
+        ImmutableList.of(
+            row(1L, GEOM_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
+            row(2L, null, null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            TABLE));
+  }
+
+  private void setVectorization(boolean on) {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('read.parquet.vectorization.enabled'='%s')",
+        TABLE, Boolean.toString(on));
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
@@ -554,7 +554,7 @@ public class TestVariantShredding extends CatalogTestBase {
         field(
             "value",
             optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-                .length(16)
+                .length(9) // decimalRequiredBytes(21)
                 .as(LogicalTypeAnnotation.decimalType(6, 21))
                 .named("typed_value"));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
@@ -992,6 +992,24 @@ public class TestVariantShredding extends CatalogTestBase {
     assertThat(rows.get(3)[1]).isEqualTo(new BigDecimal("123456.7800"));
     assertThat(rows.get(4)[1]).isEqualTo(new BigDecimal("1.2345"));
     assertThat(rows.get(5)[1]).isEqualTo(new BigDecimal("12.3000"));
+  }
+
+  @TestTemplate
+  public void testShreddedLargeIntegerVariantReadBack() {
+    // DECIMAL16 (20-digit integer, above Long.MAX_VALUE) shreds to a FIXED_LEN_BYTE_ARRAY
+    // typed_value whose declared length must equal what FixedDecimalWriter emits.
+    spark.conf().set(SparkSQLProperties.SHRED_VARIANTS, "true");
+
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"v\":12345678901234567890}')), "
+            + "(2, parse_json('{\"v\":-12345678901234567890}'))",
+        tableName);
+
+    List<Object[]> values =
+        sql("SELECT variant_get(address, '$.v', 'decimal(38,0)') FROM %s ORDER BY id", tableName);
+    assertThat(values.get(0)[0]).isEqualTo(new BigDecimal("12345678901234567890"));
+    assertThat(values.get(1)[0]).isEqualTo(new BigDecimal("-12345678901234567890"));
   }
 
   private void verifyParquetSchema(Table table, MessageType expectedSchema) throws IOException {


### PR DESCRIPTION
## Summary

Fix Spark 4.1 V2 view rename target resolution so an unqualified rename target keeps the source view namespace instead of being resolved through the current session namespace.

## Root Cause

`ExtendedDataSourceV2Strategy` resolved the rename target with `Spark3Util.catalogAndIdentifier` before deciding whether the target was actually unqualified. For a single-part target name, that helper fills in the current namespace, which can differ from the source view namespace.

## Changes

- Resolve single-part view rename targets by applying the source view namespace directly.
- Resolve multi-part targets relative to the source catalog and keep the existing cross-catalog move rejection.
- Add a Spark 4.1 regression test covering a qualified source view renamed to an unqualified target while the session is using another namespace.

## Validation

- `git diff --check HEAD^..HEAD`
- Spark tests not run per request.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed
- Prompt Summary: Fix and publish a Spark 4.1 PR for view rename namespace resolution.